### PR TITLE
Restore hourly_job config, document deprecation

### DIFF
--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -50,21 +50,21 @@ jobs:
             exit 1
           fi
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hardened Images registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.DHI_REGISTRY }}
           username: ${{ vars.DHI_USERNAME }}
@@ -73,7 +73,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -99,7 +99,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -51,6 +51,8 @@ jobs:
           fi
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
       - name: Set up Docker Buildx

--- a/.github/workflows/codecov-validate.yaml
+++ b/.github/workflows/codecov-validate.yaml
@@ -1,0 +1,25 @@
+name: codecov-config-validator
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - codecov.yml
+      - .github/workflows/codecov-validate.yaml
+  pull_request:
+    paths:
+      - codecov.yml
+      - .github/workflows/codecov-validate.yaml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - name: Validate Codecov config
+        run: curl --fail-with-body --silent --show-error --request POST --data-binary @codecov.yml https://api.codecov.io/validate

--- a/.github/workflows/codecov-validate.yaml
+++ b/.github/workflows/codecov-validate.yaml
@@ -21,5 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
       - name: Validate Codecov config
         run: curl --fail-with-body --silent --show-error --request POST --data-binary @codecov.yml https://api.codecov.io/validate

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -18,6 +18,8 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -17,14 +17,14 @@ jobs:
       #----------------------------------------------
       #       check-out repo and set-up python
       #----------------------------------------------
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.14'
           architecture: x64
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
         with:
           enable-cache: true
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
       - name: Audit dependencies with uv
         run: uv audit --frozen --preview-features audit
       - name: Upload coverage
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
@@ -44,7 +44,7 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: true
       - name: Upload test results to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -18,8 +18,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: suzuki-shunsuke/github-action-renovate-config-validator@ee9f69e1f683ed0d08225086482b34fc9abe9300 # v2.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@ee9f69e1f683ed0d08225086482b34fc9abe9300  # v2.1.0
         with:
           config_file_path: renovate.json
           strict: 'true'

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@ee9f69e1f683ed0d08225086482b34fc9abe9300  # v2.1.0
         with:
           config_file_path: renovate.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,10 +31,16 @@ repos:
       - id: trailing-whitespace
         exclude: \.md$
       - id: end-of-file-fixer
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.264.2
+    hooks:
+      - id: renovate-config-validator
+        args:
+          - --strict
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.4
     hooks:
-      - id: check-renovate
+      - id: check-codecov
       - id: check-compose-spec
       - id: check-github-workflows
   - repo: local

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ This config option will rename series or movie folders when they no longer match
 
 ### Series Scanner (Sonarr Only)
 
+> [!IMPORTANT]
+> This feature is in maintenance mode and will not receive further development or enhancements. Its usage will be evaluated in the future to determine whether it should be removed completely.
+
 This job uses the [Sonarr API](https://sonarr.tv/docs/api/) to do the following
 
 - Iterate over continuing [series](https://sonarr.tv/docs/api/#/Series/get_api_v3_series)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This job uses the [Sonarr API](https://sonarr.tv/docs/api/) to do the following
   - With a title of TBA (excluding specials)
     - will trigger a series refresh, to hopefully pull new info from The TVDB
 
-This should prevent too many API calls to the TVDB, refreshing individual series, hourly
+This should prevent too many API calls to the TVDB. When recurring scans are enabled, individual series are checked every 55–65 minutes.
 
 ### Usage
 
@@ -70,7 +70,7 @@ Logs are always written to stdout.
 
 Set `sonarr[].renamarr.log_to_file` or `radarr[].renamarr.log_to_file` to `true` to enable per-instance log files. If the target log path is not writable, renamarr logs a warning to stdout and continues running without logging to file.
 
-When enabled, logs for that instance are written under `/logs` using one of these paths:
+When enabled, logs for that instance are written under `LOG_DIR` (`/logs` by default) using one of these paths:
 
 - `sonarr/<name>.log`
 - `radarr/<name>.log`
@@ -84,6 +84,7 @@ _To avoid permission issues when creating log files, set the user option in dock
 | Environment Variable | Description                                                                                           | Default  |
 | -------------------- | ----------------------------------------------------------------------------------------------------- | -------- |
 | `LOG_LEVEL`          | Log level passed to Loguru for stdout and file sinks. `DEBUG` also adds source location to log lines. | `INFO`   |
+| `LOG_DIR`            | Directory containing per-instance log files.                                                          | `/logs`  |
 | `LOG_ROTATION`       | Rotation schedule passed to Loguru for file log rotation.                                             | `00:00`  |
 | `LOG_RETENTION`      | Retention period passed to Loguru for rotated log files.                                              | `7 days` |
 
@@ -93,31 +94,35 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 
 | Name                                          | Type    | Required | Default Value | Description                                                                                                                                      |
 | --------------------------------------------- | ------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sonarr`                                      | Array   | Yes      | []            | One or more sonarr instances                                                                                                                     |
+| `sonarr`                                      | Array   | No       | []            | Sonarr instances; when present, must contain at least one instance                                                                               |
 | `sonarr[].name`                               | string  | Yes      | N/A           | user friendly instance name, used in log messages                                                                                                |
 | `sonarr[].url`                                | string  | Yes      | N/A           | url for sonarr instance                                                                                                                          |
 | `sonarr[].api_key`                            | string  | Yes      | N/A           | api_key for sonarr instance                                                                                                                      |
 | `sonarr[].series_scanner.enabled`             | boolean | No       | False         | enables/disables series_scanner functionality                                                                                                    |
-| `sonarr[].series_scanner.hourly_job`          | boolean | No       | False         | disables hourly job. App will exit after first execution                                                                                         |
+| `sonarr[].series_scanner.hourly_job`          | boolean | No       | False         | enables recurring scans every 55–65 minutes; when false, the scanner runs once at startup                                                        |
 | `sonarr[].series_scanner.hours_before_air`    | integer | No       | 4             | The number of hours before an episode has aired, to trigger a rescan when title is TBA                                                           |
 | `sonarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
-| `sonarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** use `sonarr[].renamarr.schedule.enabled`; retained as a compatibility alias and logs a warning when configured and when jobs run |
+| `sonarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
 | `sonarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `sonarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
 | `sonarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `sonarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
 | `sonarr[].renamarr.analyze_files`             | boolean | No       | False         | This will initiate a rescan of the files in your library. This is helpful if you are transcoding files, and the audio/video codecs have changed. |
 | `sonarr[].renamarr.rename_folders`            | boolean | No       | False         | This will rename series folders when the current series folder no longer matches your MediaFormat                                                |
-| `sonarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Sonarr instance to `/logs/sonarr/<name>.log` with daily rotation                                                            |
+| `sonarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Sonarr instance to `LOG_DIR/sonarr/<name>.log` with daily rotation                                                          |
+| `radarr`                                      | Array   | No       | []            | Radarr instances; when present, must contain at least one instance                                                                               |
+| `radarr[].name`                               | string  | Yes      | N/A           | user friendly instance name, used in log messages                                                                                                |
+| `radarr[].url`                                | string  | Yes      | N/A           | url for radarr instance                                                                                                                          |
+| `radarr[].api_key`                            | string  | Yes      | N/A           | api_key for radarr instance                                                                                                                      |
 | `radarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
-| `radarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** use `radarr[].renamarr.schedule.enabled`; retained as a compatibility alias and logs a warning when configured and when jobs run |
+| `radarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
 | `radarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `radarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
 | `radarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `radarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
 | `radarr[].renamarr.analyze_files`             | boolean | No       | False         | This will initiate a rescan of the files in your library. This is helpful if you are transcoding files, and the audio/video codecs have changed. |
 | `radarr[].renamarr.rename_folders`            | boolean | No       | False         | This will rename movie folders when the current movie folder no longer matches your MediaFormat                                                  |
-| `radarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Radarr instance to `/logs/radarr/<name>.log` with daily rotation                                                            |
+| `radarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Radarr instance to `LOG_DIR/radarr/<name>.log` with daily rotation                                                          |
 
 Schedule interval values must be non-negative integers. When scheduling is enabled, the combined interval must be greater than zero. A zero interval is valid only when `schedule.enabled` is `false`.
 

--- a/README.md
+++ b/README.md
@@ -101,21 +101,27 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `sonarr[].series_scanner.hourly_job`          | boolean | No       | False         | disables hourly job. App will exit after first execution                                                                                         |
 | `sonarr[].series_scanner.hours_before_air`    | integer | No       | 4             | The number of hours before an episode has aired, to trigger a rescan when title is TBA                                                           |
 | `sonarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
+| `sonarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** use `sonarr[].renamarr.schedule.enabled`; retained as a compatibility alias and logs a warning when configured and when jobs run |
 | `sonarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `sonarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
-| `sonarr[].renamarr.schedule.interval.hours`   | integer | No       | 1             | hours between Renamarr jobs                                                                                                                      |
+| `sonarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `sonarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
 | `sonarr[].renamarr.analyze_files`             | boolean | No       | False         | This will initiate a rescan of the files in your library. This is helpful if you are transcoding files, and the audio/video codecs have changed. |
 | `sonarr[].renamarr.rename_folders`            | boolean | No       | False         | This will rename series folders when the current series folder no longer matches your MediaFormat                                                |
 | `sonarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Sonarr instance to `/logs/sonarr/<name>.log` with daily rotation                                                            |
 | `radarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
+| `radarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** use `radarr[].renamarr.schedule.enabled`; retained as a compatibility alias and logs a warning when configured and when jobs run |
 | `radarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `radarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
-| `radarr[].renamarr.schedule.interval.hours`   | integer | No       | 1             | hours between Renamarr jobs                                                                                                                      |
+| `radarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `radarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
 | `radarr[].renamarr.analyze_files`             | boolean | No       | False         | This will initiate a rescan of the files in your library. This is helpful if you are transcoding files, and the audio/video codecs have changed. |
 | `radarr[].renamarr.rename_folders`            | boolean | No       | False         | This will rename movie folders when the current movie folder no longer matches your MediaFormat                                                  |
 | `radarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Radarr instance to `/logs/radarr/<name>.log` with daily rotation                                                            |
+
+Schedule interval values must be non-negative integers. When scheduling is enabled, the combined interval must be greater than zero. A zero interval is valid only when `schedule.enabled` is `false`.
+
+When `schedule.interval` is omitted or empty, Renamarr uses the default interval of one hour.
 
 ### Local Development
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: false

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,14 @@
   "extends": ["github>hollanbm/renovate-config"],
   "pinDigests": false,
   "minimumReleaseAge": "14 days",
+  "hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "dhi.io",
+      "username": "{{ secrets.DHI_USERNAME }}",
+      "password": "{{ secrets.DHI_TOKEN }}"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -1,4 +1,5 @@
-from schema import And, Optional, Use
+from loguru import logger
+from schema import And, Optional, Schema, Use
 
 from interval import Interval
 
@@ -10,17 +11,42 @@ NON_NEGATIVE_INTEGER = And(
 
 INTERVAL_SCHEMA = {
     Optional("days", default=0): NON_NEGATIVE_INTEGER,
-    Optional("hours", default=1): NON_NEGATIVE_INTEGER,
+    Optional("hours", default=0): NON_NEGATIVE_INTEGER,
     Optional("minutes", default=0): NON_NEGATIVE_INTEGER,
 }
 
 DEFAULT_INTERVAL = Interval(days=0, hours=1, minutes=0)
 DEFAULT_SCHEDULE = {"enabled": True, "interval": DEFAULT_INTERVAL}
 
+
+def _migrate_hourly_job(renamarr_config: object) -> object:
+    """Map the deprecated hourly job option to the replacement schedule option.
+
+    The deprecated field is retained for runtime warnings. Its value supplies
+    ``schedule.enabled`` only when the replacement option is not explicitly set.
+    """
+    if not isinstance(renamarr_config, dict) or "hourly_job" not in renamarr_config:
+        return renamarr_config
+
+    logger.warning(
+        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+    )
+    migrated_config = renamarr_config.copy()
+    hourly_job = migrated_config["hourly_job"]
+    schedule = migrated_config.get("schedule")
+    if schedule is None:
+        migrated_config["schedule"] = {"enabled": hourly_job}
+    elif isinstance(schedule, dict) and "enabled" not in schedule:
+        migrated_config["schedule"] = schedule | {"enabled": hourly_job}
+    return migrated_config
+
+
 SCHEDULE_SCHEMA = And(
     {
         Optional("enabled", default=True): bool,
         Optional("interval", default=DEFAULT_INTERVAL): And(
+            dict,
+            Use(lambda value: value or {"hours": 1}),
             INTERVAL_SCHEMA,
             Use(
                 lambda value: Interval(
@@ -85,13 +111,22 @@ CONFIG_SCHEMA = {
                         schedule=DEFAULT_SCHEDULE,
                     ),
                     ignore_extra_keys=True,
-                ): {
-                    Optional("enabled", default=False): bool,
-                    Optional("analyze_files", default=False): bool,
-                    Optional("rename_folders", default=False): bool,
-                    Optional("log_to_file", default=False): bool,
-                    Optional("schedule", default=DEFAULT_SCHEDULE): SCHEDULE_SCHEMA,
-                },
+                ): And(
+                    Use(_migrate_hourly_job),
+                    Schema(
+                        {
+                            Optional("enabled", default=False): bool,
+                            Optional("hourly_job"): bool,
+                            Optional("analyze_files", default=False): bool,
+                            Optional("rename_folders", default=False): bool,
+                            Optional("log_to_file", default=False): bool,
+                            Optional(
+                                "schedule", default=DEFAULT_SCHEDULE
+                            ): SCHEDULE_SCHEMA,
+                        },
+                        ignore_extra_keys=True,
+                    ),
+                ),
             }
         ],
         ignore_extra_keys=True,
@@ -132,13 +167,22 @@ CONFIG_SCHEMA = {
                         schedule=DEFAULT_SCHEDULE,
                     ),
                     ignore_extra_keys=True,
-                ): {
-                    Optional("enabled", default=False): bool,
-                    Optional("analyze_files", default=False): bool,
-                    Optional("rename_folders", default=False): bool,
-                    Optional("log_to_file", default=False): bool,
-                    Optional("schedule", default=DEFAULT_SCHEDULE): SCHEDULE_SCHEMA,
-                },
+                ): And(
+                    Use(_migrate_hourly_job),
+                    Schema(
+                        {
+                            Optional("enabled", default=False): bool,
+                            Optional("hourly_job"): bool,
+                            Optional("analyze_files", default=False): bool,
+                            Optional("rename_folders", default=False): bool,
+                            Optional("log_to_file", default=False): bool,
+                            Optional(
+                                "schedule", default=DEFAULT_SCHEDULE
+                            ): SCHEDULE_SCHEMA,
+                        },
+                        ignore_extra_keys=True,
+                    ),
+                ),
             }
         ],
         ignore_extra_keys=True,

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -33,10 +33,12 @@ def _migrate_hourly_job(renamarr_config: object) -> object:
     )
     migrated_config = renamarr_config.copy()
     hourly_job = migrated_config["hourly_job"]
-    schedule = migrated_config.get("schedule")
-    if schedule is None:
+    if "schedule" not in migrated_config:
         migrated_config["schedule"] = {"enabled": hourly_job}
-    elif isinstance(schedule, dict) and "enabled" not in schedule:
+    elif (
+        isinstance(schedule := migrated_config["schedule"], dict)
+        and "enabled" not in schedule
+    ):
         migrated_config["schedule"] = schedule | {"enabled": hourly_job}
     return migrated_config
 

--- a/src/main.py
+++ b/src/main.py
@@ -97,16 +97,27 @@ class Main:
 
     def __sonarr_renamarr_job(self, sonarr_config):
         with logger.contextualize(service="sonarr", instance=sonarr_config.name):
+            uses_deprecated_hourly_job = hasattr(sonarr_config.renamarr, "hourly_job")
+            if uses_deprecated_hourly_job:
+                logger.warning(
+                    "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+                )
             try:
-                SonarrRenamarr(
-                    name=sonarr_config.name,
-                    url=sonarr_config.url,
-                    api_key=sonarr_config.api_key,
-                    analyze_files=sonarr_config.renamarr.analyze_files,
-                    rename_folders=sonarr_config.renamarr.rename_folders,
-                ).scan()
-            except CliArrError as exc:
-                logger.error(exc)
+                try:
+                    SonarrRenamarr(
+                        name=sonarr_config.name,
+                        url=sonarr_config.url,
+                        api_key=sonarr_config.api_key,
+                        analyze_files=sonarr_config.renamarr.analyze_files,
+                        rename_folders=sonarr_config.renamarr.rename_folders,
+                    ).scan()
+                except CliArrError as exc:
+                    logger.error(exc)
+            finally:
+                if uses_deprecated_hourly_job:
+                    logger.warning(
+                        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+                    )
 
     def __schedule_radarr_renamarr(self, radarr_config):
         self.__radarr_renamarr_job(radarr_config)
@@ -118,16 +129,27 @@ class Main:
 
     def __radarr_renamarr_job(self, radarr_config):
         with logger.contextualize(service="radarr", instance=radarr_config.name):
+            uses_deprecated_hourly_job = hasattr(radarr_config.renamarr, "hourly_job")
+            if uses_deprecated_hourly_job:
+                logger.warning(
+                    "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+                )
             try:
-                RadarrRenamarr(
-                    name=radarr_config.name,
-                    url=radarr_config.url,
-                    api_key=radarr_config.api_key,
-                    analyze_files=radarr_config.renamarr.analyze_files,
-                    rename_folders=radarr_config.renamarr.rename_folders,
-                ).scan()
-            except CliArrError as exc:
-                logger.error(exc)
+                try:
+                    RadarrRenamarr(
+                        name=radarr_config.name,
+                        url=radarr_config.url,
+                        api_key=radarr_config.api_key,
+                        analyze_files=radarr_config.renamarr.analyze_files,
+                        rename_folders=radarr_config.renamarr.rename_folders,
+                    ).scan()
+                except CliArrError as exc:
+                    logger.error(exc)
+            finally:
+                if uses_deprecated_hourly_job:
+                    logger.warning(
+                        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+                    )
 
     def __schedule_sonarr_renamarr(self, sonarr_config):
         self.__sonarr_renamarr_job(sonarr_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from typing import List
+from unittest.mock import MagicMock
 
 import pytest
 from loguru import logger
@@ -47,7 +48,7 @@ def mock_loguru_debug(mocker) -> None:
 
 
 @pytest.fixture
-def mock_loguru_warning(mocker) -> None:
+def mock_loguru_warning(mocker) -> MagicMock:
     return mocker.patch.object(logger, "warning")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from loguru import logger
 from pycliarr.api import RadarrCli, RadarrMovieItem, SonarrCli, SonarrSerieItem
 from pycliarr.api.base_api import json_data
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture
@@ -48,7 +49,7 @@ def mock_loguru_debug(mocker) -> None:
 
 
 @pytest.fixture
-def mock_loguru_warning(mocker) -> MagicMock:
+def mock_loguru_warning(mocker: MockerFixture) -> MagicMock:
     return mocker.patch.object(logger, "warning")
 
 

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -173,7 +173,9 @@ def test_boolean_fields_reject_non_bool_values(
     ("configured", "expected"),
     [
         ({}, Interval(days=0, hours=1, minutes=0)),
-        ({"minutes": 30}, Interval(days=0, hours=1, minutes=30)),
+        ({"minutes": 30}, Interval(days=0, hours=0, minutes=30)),
+        ({"days": 2}, Interval(days=2, hours=0, minutes=0)),
+        ({"hours": 3}, Interval(days=0, hours=3, minutes=0)),
         ({"days": 2, "hours": 3, "minutes": 4}, Interval(2, 3, 4)),
         ({"days": 0, "hours": 0, "minutes": 5}, Interval(0, 0, 5)),
     ],
@@ -208,6 +210,81 @@ def test_disabled_schedule_accepts_zero_interval(service: str) -> None:
 
     assert validated[service][0]["renamarr"]["schedule"]["interval"] == Interval(
         0, 0, 0
+    )
+
+
+@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("hourly_job", [True, False])
+def test_deprecated_hourly_job_sets_schedule_enabled(
+    service: str, hourly_job: bool, mock_loguru_warning
+) -> None:
+    instance_config: dict[str, object] = minimal_instance_config() | {
+        "renamarr": {"hourly_job": hourly_job}
+    }
+
+    validated = validate_config({service: [instance_config]})
+
+    assert validated[service][0]["renamarr"]["hourly_job"] is hourly_job
+    assert validated[service][0]["renamarr"]["schedule"]["enabled"] is hourly_job
+    mock_loguru_warning.assert_called_once_with(
+        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+    )
+
+
+@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
+    service: str, mock_loguru_warning
+) -> None:
+    instance_config: dict[str, object] = minimal_instance_config() | {
+        "renamarr": {
+            "hourly_job": False,
+            "schedule": {"interval": {"minutes": 30}},
+        }
+    }
+
+    validated = validate_config({service: [instance_config]})
+
+    assert validated[service][0]["renamarr"]["schedule"] == {
+        "enabled": False,
+        "interval": Interval(days=0, hours=0, minutes=30),
+    }
+    mock_loguru_warning.assert_called_once_with(
+        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+    )
+
+
+@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
+    service: str, mock_loguru_warning
+) -> None:
+    instance_config: dict[str, object] = minimal_instance_config() | {
+        "renamarr": {
+            "hourly_job": False,
+            "schedule": {"enabled": True},
+        }
+    }
+
+    validated = validate_config({service: [instance_config]})
+
+    assert validated[service][0]["renamarr"]["schedule"]["enabled"] is True
+    mock_loguru_warning.assert_called_once_with(
+        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+    )
+
+
+@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+def test_deprecated_hourly_job_does_not_hide_invalid_schedule(
+    service: str, mock_loguru_warning
+) -> None:
+    instance_config: dict[str, object] = minimal_instance_config() | {
+        "renamarr": {"hourly_job": True, "schedule": "hourly"}
+    }
+
+    with pytest.raises(SchemaError):
+        validate_config({service: [instance_config]})
+
+    mock_loguru_warning.assert_called_once_with(
+        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
     )
 
 

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from schema import Schema, SchemaError
 
@@ -216,7 +218,7 @@ def test_disabled_schedule_accepts_zero_interval(service: str) -> None:
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 @pytest.mark.parametrize("hourly_job", [True, False])
 def test_deprecated_hourly_job_sets_schedule_enabled(
-    service: str, hourly_job: bool, mock_loguru_warning
+    service: str, hourly_job: bool, mock_loguru_warning: MagicMock
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {"hourly_job": hourly_job}
@@ -233,7 +235,7 @@ def test_deprecated_hourly_job_sets_schedule_enabled(
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
-    service: str, mock_loguru_warning
+    service: str, mock_loguru_warning: MagicMock
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
@@ -255,7 +257,7 @@ def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
-    service: str, mock_loguru_warning
+    service: str, mock_loguru_warning: MagicMock
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
@@ -273,11 +275,12 @@ def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("schedule", [None, "hourly"])
 def test_deprecated_hourly_job_does_not_hide_invalid_schedule(
-    service: str, mock_loguru_warning
+    service: str, schedule: object, mock_loguru_warning: MagicMock
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
-        "renamarr": {"hourly_job": True, "schedule": "hourly"}
+        "renamarr": {"hourly_job": True, "schedule": schedule}
     }
 
     with pytest.raises(SchemaError):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -334,6 +334,36 @@ class TestMain:
         job.assert_called()
         run_pending.assert_called_once()
 
+    @pytest.mark.parametrize("service", ["sonarr", "radarr"])
+    def test_deprecated_hourly_job_warns_before_and_after_renamarr_job(
+        self, config, service, mock_loguru_warning, mocker
+    ) -> None:
+        service_config = getattr(config, service)[0]
+        service_config.renamarr.enabled = True
+        service_config.renamarr.hourly_job = True
+        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
+        mocker.patch.object(Job, "do")
+        renamarr = mocker.patch(
+            "main.SonarrRenamarr" if service == "sonarr" else "main.RadarrRenamarr"
+        )
+
+        Main().start()
+
+        renamarr.return_value.scan.assert_called_once_with()
+        deprecation_warnings = [
+            call
+            for call in mock_loguru_warning.call_args_list
+            if "renamarr.hourly_job is deprecated" in call.args[0]
+        ]
+        assert deprecation_warnings == [
+            mocker.call(
+                "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+            ),
+            mocker.call(
+                "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
+            ),
+        ]
+
     def test_sonarr_renamarr_pycliarr_exception(
         self, config, mock_loguru_error, mocker
     ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -336,7 +336,7 @@ class TestMain:
 
     @pytest.mark.parametrize("service", ["sonarr", "radarr"])
     def test_deprecated_hourly_job_warns_before_and_after_renamarr_job(
-        self, config, service, mock_loguru_warning, mocker
+        self, config, service: str, mock_loguru_warning, mocker
     ) -> None:
         service_config = getattr(config, service)[0]
         service_config.renamarr.enabled = True
@@ -346,22 +346,32 @@ class TestMain:
         renamarr = mocker.patch(
             "main.SonarrRenamarr" if service == "sonarr" else "main.RadarrRenamarr"
         )
+        warning_message = (
+            "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled "
+            "instead. Alternatively, remove renamarr.hourly_job to use the default "
+            "hourly schedule."
+        )
+        events: list[str] = []
+
+        def record_warning(message: object) -> None:
+            if message == warning_message:
+                events.append("warning")
+
+        mock_loguru_warning.side_effect = record_warning
+        renamarr.return_value.scan.side_effect = lambda: events.append("scan")
 
         Main().start()
 
         renamarr.return_value.scan.assert_called_once_with()
+        assert events == ["warning", "scan", "warning"]
         deprecation_warnings = [
             call
             for call in mock_loguru_warning.call_args_list
             if "renamarr.hourly_job is deprecated" in call.args[0]
         ]
         assert deprecation_warnings == [
-            mocker.call(
-                "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-            ),
-            mocker.call(
-                "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-            ),
+            mocker.call(warning_message),
+            mocker.call(warning_message),
         ]
 
     def test_sonarr_renamarr_pycliarr_exception(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the deprecated `renamarr.hourly_job` setting as an alias for schedule activation.
  * Added validation for Codecov configuration changes in CI.

* **Bug Fixes**
  * Corrected default scheduling interval handling when only minutes are configured.
  * Added warnings when the deprecated scheduling setting is used.

* **Documentation**
  * Updated configuration guidance, defaults, migration behavior, and scheduling constraints.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->