### PR TITLE
Restore previous schema behavior defaults

### DIFF
--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -42,7 +42,7 @@ jobs:
           DHI_PAT: ${{ secrets.DHI_PAT }}
         run: |
           if [ -z "$DHI_PAT" ]; then
-            echo "::error title=Missing secret::DHI_PAT must be configured for this workflow."
+            echo "::error title=Missing secret::DHI_PAT must be configured as an Actions secret and a Dependabot secret."
             exit 1
           fi
       - name: Checkout repository

--- a/.github/workflows/buildImage.yaml
+++ b/.github/workflows/buildImage.yaml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a Docker image
+name: Build and publish Docker images
 
 on:
   release:
@@ -10,8 +10,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
   push:
     branches:
       - main
@@ -23,8 +21,6 @@ env:
 
 jobs:
   build-and-push-image:
-    # Only build PR images when explicitly requested via label.
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-image') }}
     name: Docker image (${{ matrix.variant.name }})
     runs-on: ubuntu-latest
     strategy:
@@ -58,8 +54,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
+        if: ${{ github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -100,13 +96,13 @@ jobs:
             org.opencontainers.image.description=${{ github.event.repository.description }}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
           build-args: |
             RUNTIME_IMAGE=${{ matrix.variant.runtime_image }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -135,4 +135,6 @@ When `schedule.interval` is omitted or empty, Renamarr uses the default interval
 
 See [Local Development](docs/local-development.md) for local development requirements, environment details, and startup commands.
 
+CI builds both container variants for every configured workflow trigger. Runs initiated by Renovate or Dependabot validate the build without publishing images.
+
 Dependency audits are run with `uv audit --frozen --preview-features audit`.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This should prevent too many API calls to the TVDB. When recurring scans are ena
 
 ### Usage
 
-The application runs enabled jobs immediately on startup. Renamarr jobs repeat every hour by default. Set `renamarr.schedule.enabled` to `false` to run once, or configure the interval in days, hours, and minutes.
+The application runs enabled jobs immediately on startup. Renamarr jobs run once by default. Set `renamarr.schedule.enabled` to `true` to repeat the job, and configure the interval in days, hours, and minutes when needed.
 
 Logs are always written to stdout.
 
@@ -106,7 +106,7 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `sonarr[].series_scanner.hours_before_air`    | integer | No       | 4             | The number of hours before an episode has aired, to trigger a rescan when title is TBA                                                           |
 | `sonarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
 | `sonarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
-| `sonarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
+| `sonarr[].renamarr.schedule.enabled`          | boolean | No       | False         | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `sonarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
 | `sonarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `sonarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
@@ -119,7 +119,7 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `radarr[].api_key`                            | string  | Yes      | N/A           | api_key for radarr instance                                                                                                                      |
 | `radarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
 | `radarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
-| `radarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
+| `radarr[].renamarr.schedule.enabled`          | boolean | No       | False         | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `radarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
 | `radarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `radarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
@@ -127,7 +127,7 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `radarr[].renamarr.rename_folders`            | boolean | No       | False         | This will rename movie folders when the current movie folder no longer matches your MediaFormat                                                  |
 | `radarr[].renamarr.log_to_file`               | boolean | No       | False         | writes logs for this Radarr instance to `LOG_DIR/radarr/<name>.log` with daily rotation                                                          |
 
-Schedule interval values must be non-negative integers. When scheduling is enabled, the combined interval must be greater than zero. A zero interval is valid only when `schedule.enabled` is `false`.
+Schedule interval values must be non-negative integers, and the combined interval cannot exceed 30 days. When scheduling is enabled, the combined interval must be greater than zero. A zero interval is valid only when `schedule.enabled` is `false`.
 
 When `schedule.interval` is omitted or empty, Renamarr uses the default interval of one hour.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ When `schedule.interval` is omitted or empty, Renamarr uses the default interval
 
 See [Local Development](docs/local-development.md) for local development requirements, environment details, and startup commands.
 
-CI builds both container variants for every configured workflow trigger. Runs initiated by Renovate or Dependabot validate the build without publishing images.
+CI builds both container variants for every configured workflow trigger. Runs initiated by Renovate or Dependabot validate the build without publishing images. Because these builds use private Docker Hardened Images, `DHI_PAT` must be configured as both an Actions secret and a Dependabot secret.
 
 Dependency audits are run with `uv audit --frozen --preview-features audit`.

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "hostType": "docker",
       "matchHost": "dhi.io",
       "username": "{{ secrets.DHI_USERNAME }}",
-      "password": "{{ secrets.DHI_TOKEN }}"
+      "password": "{{ secrets.DHI_PAT }}"
     }
   ],
   "packageRules": [

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -1,4 +1,3 @@
-from loguru import logger
 from schema import And, Optional, Schema, Use
 
 from interval import Interval
@@ -16,7 +15,8 @@ INTERVAL_SCHEMA = {
 }
 
 DEFAULT_INTERVAL = Interval(days=0, hours=1, minutes=0)
-DEFAULT_SCHEDULE = {"enabled": True, "interval": DEFAULT_INTERVAL}
+DEFAULT_SCHEDULE = {"enabled": False, "interval": DEFAULT_INTERVAL}
+MAX_INTERVAL_DAYS = 30
 
 
 def _migrate_hourly_job(renamarr_config: object) -> object:
@@ -28,9 +28,6 @@ def _migrate_hourly_job(renamarr_config: object) -> object:
     if not isinstance(renamarr_config, dict) or "hourly_job" not in renamarr_config:
         return renamarr_config
 
-    logger.warning(
-        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-    )
     migrated_config = renamarr_config.copy()
     hourly_job = migrated_config["hourly_job"]
     if "schedule" not in migrated_config:
@@ -45,7 +42,7 @@ def _migrate_hourly_job(renamarr_config: object) -> object:
 
 SCHEDULE_SCHEMA = And(
     {
-        Optional("enabled", default=True): bool,
+        Optional("enabled", default=False): bool,
         Optional("interval", default=DEFAULT_INTERVAL): And(
             dict,
             Use(lambda value: value or {"hours": 1}),
@@ -59,8 +56,14 @@ SCHEDULE_SCHEMA = And(
             ),
         ),
     },
-    lambda value: not value["enabled"] or value["interval"].total_minutes > 0,
-    error="renamarr.schedule.interval must be greater than zero when scheduling is enabled",
+    And(
+        lambda value: not value["enabled"] or value["interval"].total_minutes > 0,
+        error="renamarr.schedule.interval must be greater than zero when scheduling is enabled",
+    ),
+    And(
+        lambda value: value["interval"].total_minutes <= MAX_INTERVAL_DAYS * 1440,
+        error=f"renamarr.schedule.interval must not exceed {MAX_INTERVAL_DAYS} days",
+    ),
 )
 
 CONFIG_SCHEMA = {

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -15,8 +15,11 @@ INTERVAL_SCHEMA = {
 }
 
 DEFAULT_INTERVAL = Interval(days=0, hours=1, minutes=0)
-DEFAULT_SCHEDULE = {"enabled": False, "interval": DEFAULT_INTERVAL}
-MAX_INTERVAL_DAYS = 30
+DEFAULT_SCHEDULE: dict[str, object] = {
+    "enabled": False,
+    "interval": DEFAULT_INTERVAL,
+}
+MAX_INTERVAL_DAYS: int = 30
 
 
 def _migrate_hourly_job(renamarr_config: object) -> object:

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from renamarr.sonarr.services.renamarr import SonarrRenamarr
 from renamarr.sonarr.services.series_scanner import SonarrSeriesScanner
 
 
-_DEPRECATED_HOURLY_JOB_WARNING = (
+_DEPRECATED_HOURLY_JOB_WARNING: str = (
     "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. "
     "Remove renamarr.hourly_job after migrating the schedule configuration."
 )

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,12 @@ from renamarr.sonarr.services.renamarr import SonarrRenamarr
 from renamarr.sonarr.services.series_scanner import SonarrSeriesScanner
 
 
+_DEPRECATED_HOURLY_JOB_WARNING = (
+    "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. "
+    "Remove renamarr.hourly_job after migrating the schedule configuration."
+)
+
+
 class Main:
     """
     This class handles config parsing, and job scheduling
@@ -99,9 +105,7 @@ class Main:
         with logger.contextualize(service="sonarr", instance=sonarr_config.name):
             uses_deprecated_hourly_job = hasattr(sonarr_config.renamarr, "hourly_job")
             if uses_deprecated_hourly_job:
-                logger.warning(
-                    "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-                )
+                logger.warning(_DEPRECATED_HOURLY_JOB_WARNING)
             try:
                 try:
                     SonarrRenamarr(
@@ -115,9 +119,7 @@ class Main:
                     logger.error(exc)
             finally:
                 if uses_deprecated_hourly_job:
-                    logger.warning(
-                        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-                    )
+                    logger.warning(_DEPRECATED_HOURLY_JOB_WARNING)
 
     def __schedule_radarr_renamarr(self, radarr_config):
         self.__radarr_renamarr_job(radarr_config)
@@ -131,9 +133,7 @@ class Main:
         with logger.contextualize(service="radarr", instance=radarr_config.name):
             uses_deprecated_hourly_job = hasattr(radarr_config.renamarr, "hourly_job")
             if uses_deprecated_hourly_job:
-                logger.warning(
-                    "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-                )
+                logger.warning(_DEPRECATED_HOURLY_JOB_WARNING)
             try:
                 try:
                     RadarrRenamarr(
@@ -147,9 +147,7 @@ class Main:
                     logger.error(exc)
             finally:
                 if uses_deprecated_hourly_job:
-                    logger.warning(
-                        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-                    )
+                    logger.warning(_DEPRECATED_HOURLY_JOB_WARNING)
 
     def __schedule_sonarr_renamarr(self, sonarr_config):
         self.__sonarr_renamarr_job(sonarr_config)

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -43,7 +43,7 @@ def test_minimal_sonarr_config_receives_defaults() -> None:
                 "rename_folders": False,
                 "log_to_file": False,
                 "schedule": {
-                    "enabled": True,
+                    "enabled": False,
                     "interval": Interval(days=0, hours=1, minutes=0),
                 },
             },
@@ -66,7 +66,7 @@ def test_minimal_radarr_config_receives_defaults() -> None:
                 "rename_folders": False,
                 "log_to_file": False,
                 "schedule": {
-                    "enabled": True,
+                    "enabled": False,
                     "interval": Interval(days=0, hours=1, minutes=0),
                 },
             },
@@ -177,6 +177,7 @@ def test_boolean_fields_reject_non_bool_values(
         ({}, Interval(days=0, hours=1, minutes=0)),
         ({"minutes": 30}, Interval(days=0, hours=0, minutes=30)),
         ({"days": 2}, Interval(days=2, hours=0, minutes=0)),
+        ({"days": 30}, Interval(days=30, hours=0, minutes=0)),
         ({"hours": 3}, Interval(days=0, hours=3, minutes=0)),
         ({"days": 2, "hours": 3, "minutes": 4}, Interval(2, 3, 4)),
         ({"days": 0, "hours": 0, "minutes": 5}, Interval(0, 0, 5)),
@@ -192,7 +193,7 @@ def test_schedule_interval_is_validated(
     validated = validate_config({service: [instance_config]})
 
     assert validated[service][0]["renamarr"]["schedule"] == {
-        "enabled": True,
+        "enabled": False,
         "interval": expected,
     }
 
@@ -217,7 +218,7 @@ def test_disabled_schedule_accepts_zero_interval(service: str) -> None:
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 @pytest.mark.parametrize("hourly_job", [True, False])
-def test_deprecated_hourly_job_sets_schedule_enabled(
+def test_deprecated_hourly_job_sets_schedule_enabled_without_parse_warning(
     service: str, hourly_job: bool, mock_loguru_warning: MagicMock
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
@@ -228,14 +229,12 @@ def test_deprecated_hourly_job_sets_schedule_enabled(
 
     assert validated[service][0]["renamarr"]["hourly_job"] is hourly_job
     assert validated[service][0]["renamarr"]["schedule"]["enabled"] is hourly_job
-    mock_loguru_warning.assert_called_once_with(
-        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-    )
+    mock_loguru_warning.assert_not_called()
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
-    service: str, mock_loguru_warning: MagicMock
+    service: str,
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
@@ -250,14 +249,11 @@ def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
         "enabled": False,
         "interval": Interval(days=0, hours=0, minutes=30),
     }
-    mock_loguru_warning.assert_called_once_with(
-        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-    )
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
-    service: str, mock_loguru_warning: MagicMock
+    service: str,
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
@@ -269,15 +265,12 @@ def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
     validated = validate_config({service: [instance_config]})
 
     assert validated[service][0]["renamarr"]["schedule"]["enabled"] is True
-    mock_loguru_warning.assert_called_once_with(
-        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-    )
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
 @pytest.mark.parametrize("schedule", [None, "hourly"])
 def test_deprecated_hourly_job_does_not_hide_invalid_schedule(
-    service: str, schedule: object, mock_loguru_warning: MagicMock
+    service: str, schedule: object
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {"hourly_job": True, "schedule": schedule}
@@ -286,9 +279,28 @@ def test_deprecated_hourly_job_does_not_hide_invalid_schedule(
     with pytest.raises(SchemaError):
         validate_config({service: [instance_config]})
 
-    mock_loguru_warning.assert_called_once_with(
-        "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. Alternatively, remove renamarr.hourly_job to use the default hourly schedule."
-    )
+
+@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize(
+    "interval",
+    [
+        {"days": 31},
+        {"hours": 721},
+        {"minutes": 43201},
+    ],
+)
+def test_schedule_rejects_intervals_over_thirty_days(
+    service: str, interval: dict[str, int]
+) -> None:
+    instance_config: dict[str, object] = minimal_instance_config() | {
+        "renamarr": {"schedule": {"interval": interval}}
+    }
+
+    with pytest.raises(
+        SchemaError,
+        match="renamarr.schedule.interval must not exceed 30 days",
+    ):
+        validate_config({service: [instance_config]})
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -311,10 +311,11 @@ class TestMain:
         )
         sonarr_renamarr.return_value.scan.assert_called_once_with()
 
-    def test_sonarr_renamarr_default_schedule(
+    def test_sonarr_renamarr_enabled_schedule(
         self, config, enable_scheduler, mocker
     ) -> None:
         config.sonarr[0].renamarr.enabled = True
+        config.sonarr[0].renamarr.schedule.enabled = True
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
         job = mocker.patch.object(Job, "do")
         run_pending = mocker.spy(Scheduler, "run_pending")
@@ -348,8 +349,8 @@ class TestMain:
         )
         warning_message = (
             "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled "
-            "instead. Alternatively, remove renamarr.hourly_job to use the default "
-            "hourly schedule."
+            "instead. Remove renamarr.hourly_job after migrating the schedule "
+            "configuration."
         )
         events: list[str] = []
 
@@ -542,10 +543,11 @@ class TestMain:
             mock_loguru_warning.call_args_list[-1].args[0], PermissionError
         )
 
-    def test_radarr_renamarr_default_schedule(
+    def test_radarr_renamarr_enabled_schedule(
         self, config, enable_scheduler, mocker
     ) -> None:
         config.radarr[0].renamarr.enabled = True
+        config.radarr[0].renamarr.schedule.enabled = True
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
         job = mocker.spy(Job, "do")
         run_pending = mocker.spy(Scheduler, "run_pending")
@@ -612,6 +614,7 @@ class TestMain:
 
     def test_renamarr_schedule_uses_total_minutes(self, config, mocker) -> None:
         config.radarr[0].renamarr.enabled = True
+        config.radarr[0].renamarr.schedule.enabled = True
         config.radarr[0].renamarr.schedule.interval = mocker.Mock(total_minutes=1504)
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
         every = mocker.patch("main.schedule.every")


### PR DESCRIPTION
- **Address schema regression**
- **fix renovate.json**
- **build container, but don't push when dependabot or renovate**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling is now disabled by default; enable it explicitly for recurring jobs.
  * Schedule intervals are limited to a maximum of 30 days.

* **Bug Fixes**
  * Deprecated hourly-job configuration warnings and migration behavior were clarified.

* **CI/CD**
  * Automated builds now validate bot-triggered changes without publishing container images.
  * Docker images are built and published under the updated workflow behavior.

* **Documentation**
  * Updated configuration guidance, scheduling defaults, interval limits, and CI build notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->