### PR TITLE
Update schedule to default to enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,26 @@
 
 ## Quick Start
 
-### docker
+### Docker
+
+#### Recurring job
+
+This is the default deployment mode. Enabled Renamarr jobs run immediately, repeat every hour unless configured otherwise, and the container remains running with `restart: unless-stopped`.
 
 1. Copy/Rename [config.yml.example](example/config.yml.example) to `config.yml`
 2. Update `config.yml` as needed.
    - See [Configuration](#configuration) for further explanation
 3. Bring up app using provided [docker-compose.yml](example/docker-compose.yml)
+
+#### External scheduler
+
+Each invocation runs every enabled job once and exits without restarting.
+
+1. Copy/Rename [config.yml.example](example/external-scheduler/config.yml.example) to `config.yml`
+2. Update `config.yml` as needed
+    - _Reminder to set `renamarr[].schedule.enabled: false`_
+3. Invoke the app from your scheduler using the provided [docker-compose.yml](example/external-scheduler/docker-compose.yml)
+
 
 #### Troubleshooting
 
@@ -43,6 +57,7 @@ This config option will rename series or movie folders when they no longer match
 - uses [/api/v3/movie/{id}/folder](https://radarr.video/docs/api/#/MovieFolder/get_api_v3_movie__id__folder) endpoint to determine if the movie folder requires an update
 - uses [/api/v3/movie/editor](https://radarr.video/docs/api/#/MovieEditor/put_api_v3_movie_editor) endpoint to update movie rootFolderPath to it's current value
   - moving the folder in place
+- sends a Sonarr `RescanSeries` command to rescan series after successful folder moves
 - sends a Radarr `RefreshMovie` command to rescan movies after successful folder moves
 - Series and movies are processed in bulk at the end of the run, **per root folder**
 
@@ -65,7 +80,10 @@ This should prevent too many API calls to the TVDB. When recurring scans are ena
 
 ### Usage
 
-The application runs enabled jobs immediately on startup. Renamarr jobs run once by default. Set `renamarr.schedule.enabled` to `true` to repeat the job, and configure the interval in days, hours, and minutes when needed.
+The application runs enabled jobs immediately on startup. Renamarr jobs repeat every hour by default. Set `renamarr.schedule.enabled` to `false` to run once, or configure the interval in days, hours, and minutes.
+
+The process remains running while at least one recurring job is registered. It exits after the initial run when all enabled jobs are configured for an external scheduler.
+
 
 Logs are always written to stdout.
 
@@ -106,7 +124,7 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `sonarr[].series_scanner.hours_before_air`    | integer | No       | 4             | The number of hours before an episode has aired, to trigger a rescan when title is TBA                                                           |
 | `sonarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
 | `sonarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
-| `sonarr[].renamarr.schedule.enabled`          | boolean | No       | False         | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
+| `sonarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `sonarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
 | `sonarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `sonarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
@@ -119,7 +137,7 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `radarr[].api_key`                            | string  | Yes      | N/A           | api_key for radarr instance                                                                                                                      |
 | `radarr[].renamarr.enabled`                   | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
 | `radarr[].renamarr.hourly_job`                | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
-| `radarr[].renamarr.schedule.enabled`          | boolean | No       | False         | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
+| `radarr[].renamarr.schedule.enabled`          | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
 | `radarr[].renamarr.schedule.interval.days`    | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
 | `radarr[].renamarr.schedule.interval.hours`   | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
 | `radarr[].renamarr.schedule.interval.minutes` | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
@@ -135,7 +153,7 @@ When `schedule.interval` is omitted or empty, Renamarr uses the default interval
 
 The container publishes application health through Docker's native health status. Renamarr refreshes an internal heartbeat while the scheduler is idle and from a background thread while a job is running. The health check is observational: Docker Compose's `restart` policy does not restart a running container solely because it becomes unhealthy. A logically stuck job can remain healthy while its heartbeat thread continues running.
 
-The heartbeat is stored under `/tmp`. One-shot containers may finish before Docker runs a health check. For these runs, use the container’s completion status and Renamarr logs rather than Docker health status.
+The heartbeat is stored under `/tmp`. Containers invoked by an external scheduler may finish before Docker runs a health check. For these runs, use the container’s completion status and Renamarr logs rather than Docker health status.
 
 #### Read-only Root Filesystem
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Each invocation runs every enabled job once and exits without restarting.
 
 1. Copy/Rename [config.yml.example](example/external-scheduler/config.yml.example) to `config.yml`
 2. Update `config.yml` as needed
-    - _Reminder to set `renamarr[].schedule.enabled: false`_
+   - _Reminder to set `renamarr[].schedule.enabled: false`_
 3. Invoke the app from your scheduler using the provided [docker-compose.yml](example/external-scheduler/docker-compose.yml)
-
 
 #### Troubleshooting
 
@@ -83,7 +82,6 @@ This should prevent too many API calls to the TVDB. When recurring scans are ena
 The application runs enabled jobs immediately on startup. Renamarr jobs repeat every hour by default. Set `renamarr.schedule.enabled` to `false` to run once, or configure the interval in days, hours, and minutes.
 
 The process remains running while at least one recurring job is registered. It exits after the initial run when all enabled jobs are configured for an external scheduler.
-
 
 Logs are always written to stdout.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each invocation runs every enabled job once and exits without restarting.
 
 1. Copy/Rename [config.yml.example](example/external-scheduler/config.yml.example) to `config.yml`
 2. Update `config.yml` as needed
-   - _Reminder to set `renamarr[].schedule.enabled: false`_
+   - _Set `sonarr[].renamarr.schedule.enabled: false` and/or `radarr[].renamarr.schedule.enabled: false` for every configured instance._
 3. Invoke the app from your scheduler using the provided [docker-compose.yml](example/external-scheduler/docker-compose.yml)
 
 #### Troubleshooting

--- a/example/config.yml.example
+++ b/example/config.yml.example
@@ -38,7 +38,7 @@ radarr:
       rename_folders: false
       log_to_file: true
       schedule:
-        enabled: false
+        enabled: true
   - name: radarr-4k
     url: https://radarr-4k.tld:7878
     api_key: not-a-real-api-key

--- a/example/external-scheduler/config.yml.example
+++ b/example/external-scheduler/config.yml.example
@@ -1,0 +1,26 @@
+sonarr:
+  - name: tv
+    url: https://sonarr.tld:8989
+    api_key: not-a-real-api-key
+    renamarr:
+      enabled: true
+      analyze_files: true
+      rename_folders: false
+      log_to_file: false
+      schedule:
+        enabled: false
+    series_scanner:
+      enabled: true
+      hourly_job: false
+      hours_before_air: 4
+radarr:
+  - name: radarr
+    url: https://radarr.tld:7878
+    api_key: not-a-real-api-key
+    renamarr:
+      enabled: true
+      analyze_files: false
+      rename_folders: false
+      log_to_file: false
+      schedule:
+        enabled: false

--- a/example/external-scheduler/docker-compose.yml
+++ b/example/external-scheduler/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  renamarr:
+    container_name: renamarr
+    image: ghcr.io/hollanbm/renamarr:latest
+    # user: 1000:1000  # If file logging is enabled, match the host user to avoid permission issues.
+    read_only: true
+    restart: 'no'
+    tmpfs:
+      - /tmp
+    volumes:
+      - ./config.yml:/config/config.yml:ro
+      # - ./logs:/logs:rw  # Create this directory before enabling persistent file logs.

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -16,7 +16,7 @@ INTERVAL_SCHEMA = {
 
 DEFAULT_INTERVAL = Interval(days=0, hours=1, minutes=0)
 DEFAULT_SCHEDULE: dict[str, object] = {
-    "enabled": False,
+    "enabled": True,
     "interval": DEFAULT_INTERVAL,
 }
 MAX_INTERVAL_DAYS: int = 30
@@ -45,7 +45,7 @@ def _migrate_hourly_job(renamarr_config: object) -> object:
 
 SCHEDULE_SCHEMA = And(
     {
-        Optional("enabled", default=False): bool,
+        Optional("enabled", default=True): bool,
         Optional("interval", default=DEFAULT_INTERVAL): And(
             dict,
             Use(lambda value: value or {"hours": 1}),

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -43,7 +43,7 @@ def test_minimal_sonarr_config_receives_defaults() -> None:
                 "rename_folders": False,
                 "log_to_file": False,
                 "schedule": {
-                    "enabled": False,
+                    "enabled": True,
                     "interval": Interval(days=0, hours=1, minutes=0),
                 },
             },
@@ -66,7 +66,7 @@ def test_minimal_radarr_config_receives_defaults() -> None:
                 "rename_folders": False,
                 "log_to_file": False,
                 "schedule": {
-                    "enabled": False,
+                    "enabled": True,
                     "interval": Interval(days=0, hours=1, minutes=0),
                 },
             },
@@ -193,7 +193,7 @@ def test_schedule_interval_is_validated(
     validated = validate_config({service: [instance_config]})
 
     assert validated[service][0]["renamarr"]["schedule"] == {
-        "enabled": False,
+        "enabled": True,
         "interval": expected,
     }
 
@@ -252,19 +252,23 @@ def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize(
+    ("hourly_job", "schedule_enabled"),
+    [(False, True), (True, False)],
+)
 def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
-    service: str,
+    service: str, hourly_job: bool, schedule_enabled: bool
 ) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
-            "hourly_job": False,
-            "schedule": {"enabled": True},
+            "hourly_job": hourly_job,
+            "schedule": {"enabled": schedule_enabled},
         }
     }
 
     validated = validate_config({service: [instance_config]})
 
-    assert validated[service][0]["renamarr"]["schedule"]["enabled"] is True
+    assert validated[service][0]["renamarr"]["schedule"]["enabled"] is schedule_enabled
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ from main import Main
 from pycliarr.api import CliArrError
 from pyconfigparser import ConfigError, ConfigFileNotFoundError, configparser
 from renamarr.healthcheck.health_reporter import HealthReporter
-from schedule import Job, Scheduler
+from schedule import Job, Scheduler, clear, get_jobs
 
 # disable config caching
 configparser.hold_an_instance = False
@@ -323,29 +323,61 @@ class TestMain:
         sonarr_renamarr.return_value.scan.assert_called_once_with()
         self.health_reporter.running_job.assert_called_once_with()
 
-    def test_sonarr_renamarr_enabled_schedule(
+    @pytest.mark.parametrize(
+        ("service", "renamarr_class"),
+        [
+            ("sonarr", "main.SonarrRenamarr"),
+            ("radarr", "main.RadarrRenamarr"),
+        ],
+    )
+    def test_default_renamarr_schedule_runs_immediately_and_hourly(
+        self, config, enable_scheduler, service, renamarr_class, mocker
+    ) -> None:
+        service_config = getattr(config, service)[0]
+        service_config.renamarr.enabled = True
+        assert service_config.renamarr.schedule.enabled is True
+        assert service_config.renamarr.schedule.interval.total_minutes == 60
+        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
+        run_pending = mocker.spy(Scheduler, "run_pending")
+        renamarr = mocker.patch(renamarr_class)
+        clear()
+
+        try:
+            Main().start()
+
+            renamarr.return_value.scan.assert_called_once_with()
+            jobs = get_jobs()
+            assert len(jobs) == 1
+            assert jobs[0].interval == 60
+            assert jobs[0].unit == "minutes"
+            run_pending.assert_called_once()
+            self.health_reporter.idle.assert_called_once_with()
+            self.health_reporter.heartbeat.assert_called_once_with()
+        finally:
+            clear()
+
+    def test_external_cron_does_not_disable_explicit_renamarr_schedule(
         self, config, enable_scheduler, mocker
     ) -> None:
-        config.sonarr[0].renamarr.enabled = True
-        config.sonarr[0].renamarr.schedule.enabled = True
+        config.radarr[0].renamarr.enabled = True
+        config.radarr[0].renamarr.schedule.enabled = True
+        mocker.patch.dict(os.environ, {"EXTERNAL_CRON": "TRUE"})
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
-        job = mocker.patch.object(Job, "do")
         run_pending = mocker.spy(Scheduler, "run_pending")
+        radarr_renamarr = mocker.patch("main.RadarrRenamarr")
+        clear()
 
-        sonarr_renamarr = mocker.patch("main.SonarrRenamarr")
+        try:
+            Main().start()
 
-        Main().start()
-
-        sonarr_renamarr.assert_called_once_with(
-            name=config.sonarr[0].name,
-            url=config.sonarr[0].url,
-            api_key=config.sonarr[0].api_key,
-            analyze_files=config.sonarr[0].renamarr.analyze_files,
-            rename_folders=config.sonarr[0].renamarr.rename_folders,
-        )
-        sonarr_renamarr.return_value.scan.assert_called_once_with()
-        job.assert_called()
-        run_pending.assert_called_once()
+            radarr_renamarr.return_value.scan.assert_called_once_with()
+            jobs = get_jobs()
+            assert len(jobs) == 1
+            assert jobs[0].interval == 60
+            assert jobs[0].unit == "minutes"
+            run_pending.assert_called_once()
+        finally:
+            clear()
 
     @pytest.mark.parametrize("service", ["sonarr", "radarr"])
     def test_deprecated_hourly_job_warns_before_and_after_renamarr_job(
@@ -557,30 +589,6 @@ class TestMain:
             mock_loguru_warning.call_args_list[-1].args[0], PermissionError
         )
 
-    def test_radarr_renamarr_enabled_schedule(
-        self, config, enable_scheduler, mocker
-    ) -> None:
-        config.radarr[0].renamarr.enabled = True
-        config.radarr[0].renamarr.schedule.enabled = True
-        mocker.patch("pyconfigparser.configparser.get_config").return_value = config
-        job = mocker.spy(Job, "do")
-        run_pending = mocker.spy(Scheduler, "run_pending")
-
-        radarr_renamarr = mocker.patch("main.RadarrRenamarr")
-
-        Main().start()
-
-        radarr_renamarr.assert_called_once_with(
-            name=config.radarr[0].name,
-            url=config.radarr[0].url,
-            api_key=config.radarr[0].api_key,
-            analyze_files=config.radarr[0].renamarr.analyze_files,
-            rename_folders=config.radarr[0].renamarr.rename_folders,
-        )
-        radarr_renamarr.return_value.scan.assert_called_once_with()
-        job.assert_called()
-        run_pending.assert_called_once()
-
     def test_radarr_renamarr_pycliarr_exception(
         self, config, mock_loguru_error, mocker
     ) -> None:
@@ -617,15 +625,21 @@ class TestMain:
         service_config.renamarr.enabled = True
         service_config.renamarr.schedule.enabled = False
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
-        job = mocker.patch.object(Job, "do")
+        run_pending = mocker.spy(Scheduler, "run_pending")
         renamarr = mocker.patch(
             "main.SonarrRenamarr" if service == "sonarr" else "main.RadarrRenamarr"
         )
+        clear()
 
-        Main().start()
+        try:
+            Main().start()
 
-        renamarr.return_value.scan.assert_called_once_with()
-        job.assert_not_called()
+            renamarr.return_value.scan.assert_called_once_with()
+            assert get_jobs() == []
+            run_pending.assert_not_called()
+            self.health_reporter.idle.assert_not_called()
+        finally:
+            clear()
 
     def test_renamarr_schedule_uses_total_minutes(self, config, mocker) -> None:
         config.radarr[0].renamarr.enabled = True


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renaming jobs now run hourly by default and start immediately when enabled.
  - Added an example setup for running Renamarr with an external scheduler.

- **Configuration**
  - Scheduling is now enabled by default for Sonarr and Radarr.
  - Set scheduling to disabled to run jobs once instead of recurring hourly.

- **Documentation**
  - Clarified Docker setup, scheduler behavior, process completion, and health-check expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->