### PR TITLE
Readability pass on renamarr core modules

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -2,7 +2,6 @@ from schema import And, Optional, Schema, Use
 
 from interval import Interval
 
-
 NON_NEGATIVE_INTEGER = And(
     lambda value: type(value) is int,
     lambda value: value >= 0,

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,6 @@ from renamarr.radarr.services.renamarr import RadarrRenamarr
 from renamarr.sonarr.services.renamarr import SonarrRenamarr
 from renamarr.sonarr.services.series_scanner import SonarrSeriesScanner
 
-
 _DEPRECATED_HOURLY_JOB_WARNING: str = (
     "renamarr.hourly_job is deprecated; use renamarr.schedule.enabled instead. "
     "Remove renamarr.hourly_job after migrating the schedule configuration."

--- a/src/renamarr/healthcheck/settings.py
+++ b/src/renamarr/healthcheck/settings.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 HEALTH_FILE = Path("/tmp/renamarr-health.json")
 HEARTBEAT_INTERVAL_SECONDS = 10.0
 MAX_HEARTBEAT_AGE_SECONDS = 30.0

--- a/src/renamarr/sonarr/services/series_scanner.py
+++ b/src/renamarr/sonarr/services/series_scanner.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from dateutil import parser
 from loguru import logger
@@ -40,13 +40,12 @@ class SonarrSeriesScanner:
                         if len(episode_list) == 0:
                             logger.error("Error fetching episode list")
                             continue
-                        else:
-                            logger.debug("Retrieved episode list")
+                        logger.debug("Retrieved episode list")
 
                         for episode in self.__filter_episode_list(episode_list):
                             episode_air_date_utc = parser.parse(
                                 episode["airDateUtc"]
-                            ).astimezone(timezone.utc)
+                            ).astimezone(UTC)
 
                             if self.__is_episode_airing_soon(episode_air_date_utc):
                                 logger.info(
@@ -55,7 +54,7 @@ class SonarrSeriesScanner:
                                 self.sonarr_cli.refresh_serie(show.id)
                                 logger.info("Series rescan triggered")
                                 break
-                            elif self.__has_episode_already_aired(episode_air_date_utc):
+                            if self.__has_episode_already_aired(episode_air_date_utc):
                                 logger.info(
                                     "Found previously aired episode with TBA title"
                                 )
@@ -95,7 +94,7 @@ class SonarrSeriesScanner:
         """
 
         hours_till_airing = (
-            episode_air_date_utc - datetime.now(timezone.utc)
+            episode_air_date_utc - datetime.now(UTC)
         ).total_seconds() / 3600
 
         return 0 < hours_till_airing <= self.hours_before_air
@@ -109,4 +108,4 @@ class SonarrSeriesScanner:
         bool True if episode has already aired
         """
 
-        return (datetime.now(timezone.utc) - episode_air_date_utc).total_seconds() > 0
+        return (datetime.now(UTC) - episode_air_date_utc).total_seconds() > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta, timezone
-from typing import List
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,7 +10,7 @@ from pytest_mock import MockerFixture
 
 @pytest.fixture
 def get_serie(mocker) -> None:
-    series: List[SonarrSerieItem] = [
+    series: list[SonarrSerieItem] = [
         SonarrSerieItem(id=1, title="test title", status="continuing")
     ]
     mocker.patch.object(SonarrCli, "get_serie").return_value = series
@@ -24,7 +23,7 @@ def get_serie_empty(mocker) -> None:
 
 @pytest.fixture
 def get_movie(mocker) -> None:
-    movies: List[RadarrMovieItem] = [RadarrMovieItem(id=1, title="test title")]
+    movies: list[RadarrMovieItem] = [RadarrMovieItem(id=1, title="test title")]
     mocker.patch.object(RadarrCli, "get_movie").return_value = movies
 
 
@@ -65,7 +64,7 @@ def episode_data(
     return dict(
         id=id,
         title=title,
-        airDateUtc=(datetime.now(timezone.utc) + airDateDelta).isoformat(),
+        airDateUtc=(datetime.now(UTC) + airDateDelta).isoformat(),
         seasonNumber=seasonNumber,
         episodeNumber=episodeNumber,
         hasFile=hasFile,

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -63,9 +63,8 @@ def test_running_job_returns_to_idle_after_exception(tmp_path: Path) -> None:
     path = tmp_path / "health.json"
     reporter = HealthReporter(path=path, heartbeat_interval=60.0)
 
-    with pytest.raises(RuntimeError, match="job failed"):
-        with reporter.running_job():
-            raise RuntimeError("job failed")
+    with pytest.raises(RuntimeError, match="job failed"), reporter.running_job():
+        raise RuntimeError("job failed")
 
     assert json.loads(path.read_text(encoding="utf-8"))["state"] == "idle"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,17 +1,18 @@
 import os
+from collections.abc import Generator
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Generator
 from unittest.mock import PropertyMock
 
 import pytest
 from loguru import logger
-from config_schema import CONFIG_SCHEMA
-from main import Main
 from pycliarr.api import CliArrError
 from pyconfigparser import ConfigError, ConfigFileNotFoundError, configparser
-from renamarr.healthcheck.health_reporter import HealthReporter
 from schedule import Job, Scheduler, clear, get_jobs
+
+from config_schema import CONFIG_SCHEMA
+from main import Main
+from renamarr.healthcheck.health_reporter import HealthReporter
 
 # disable config caching
 configparser.hold_an_instance = False
@@ -70,7 +71,7 @@ class TestMain:
         Disable scheduler loop for the majority of tests
         """
         Main.RUN_SCHEDULER = False
-        yield configparser.get_config(
+        return configparser.get_config(
             CONFIG_SCHEMA,
             config_dir="tests/fixtures",
             file_name="disabled.yml",

--- a/tests/test_sonarr_series_scanner.py
+++ b/tests/test_sonarr_series_scanner.py
@@ -1,15 +1,14 @@
 import logging
-from datetime import datetime, timedelta, timezone
-from typing import List
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from pycliarr.api import SonarrCli, SonarrSerieItem
 from pycliarr.api.base_api import json_data
-from renamarr.sonarr.services.series_scanner import SonarrSeriesScanner
-
 from tests.conftest import episode_data
 
-FIXED_NOW = datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+from renamarr.sonarr.services.series_scanner import SonarrSeriesScanner
+
+FIXED_NOW = datetime(2026, 1, 1, 12, tzinfo=UTC)
 
 
 def tba_episode_at(air_date_utc: datetime) -> json_data:
@@ -63,7 +62,7 @@ class TestSeriesScanner:
         assert "Error fetching episode list" in caplog.text
 
     def test_when_show_status_not_continuuing(self, caplog, mocker) -> None:
-        series: List[SonarrSerieItem] = [
+        series: list[SonarrSerieItem] = [
             SonarrSerieItem(id=1, title="test title", status="ended")
         ]
         mocker.patch.object(SonarrCli, "get_serie").return_value = series
@@ -77,7 +76,7 @@ class TestSeriesScanner:
         assert not get_episode.called
 
     def test_when_multiple_shows_continuing_and_ended(self, caplog, mocker) -> None:
-        series: List[SonarrSerieItem] = [
+        series: list[SonarrSerieItem] = [
             SonarrSerieItem(id=1, title="title 1", status="continuing"),
             SonarrSerieItem(id=2, title="title 2", status="ended"),
         ]
@@ -92,7 +91,7 @@ class TestSeriesScanner:
         get_episode.assert_called_once_with(1)
 
     def test_when_episodes_filtered_out(self, get_serie, caplog, mocker) -> None:
-        episodes: List[json_data] = [
+        episodes: list[json_data] = [
             episode_data(
                 id=1,
                 title="TBA",
@@ -127,7 +126,7 @@ class TestSeriesScanner:
         assert not refresh_serie.called
 
     def test_when_tba_episode_is_airing_soon(self, get_serie, caplog, mocker) -> None:
-        episodes: List[json_data] = [
+        episodes: list[json_data] = [
             episode_data(
                 id=1,
                 title="TBA",
@@ -149,7 +148,7 @@ class TestSeriesScanner:
     def test_when_tba_episode_has_already_aired(
         self, get_serie, caplog, mocker
     ) -> None:
-        episodes: List[json_data] = [
+        episodes: list[json_data] = [
             episode_data(
                 id=1,
                 title="TBA",


### PR DESCRIPTION
Small readability fixes in the renamarr CLI and scanner modules from a ShipGate auto-fix pass on core source dirs.

## Summary

ShipGate reported **~335 format/style findings**, **~463 lint findings** in the full check suite. Security, duplication, and maintainability dimensions are summarized below; see the linked gist for raw captures.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.
### File hotspots

| File | Issues | Action |
| --- | ---: | --- |
| `tests/test_sonarr_series_folder_rename.py` | ~73 lint | use literal collection calls instead of constructors (C408); address PLR6301 |
| `tests/test_main.py` | ~70 lint | address PLR6301; address ARG002 |
| `tests/test_radarr_movie_folder_rename.py` | ~70 lint | use literal collection calls instead of constructors (C408); address PLR6301 |
| `tests/test_sonarr_series_scanner.py` | ~41 lint | address PLR6301; address ARG002 |
| `src/main.py` | ~23 lint | address DEP001; address unresolved-import |
| `tests/conftest.py` | ~19 lint | address N803; address unresolved-import |
| `src/config_schema.py` | ~14 lint | use literal collection calls instead of constructors (C408); address invalid-argument-type |
| `src/renamarr/sonarr/services/series_scanner.py` | ~14 lint | address unresolved-import; address UP017 |
| `tests/test_config_schema.py` | ~14 lint | address not-subscriptable; address FBT001 |
## What you are doing right

- **Security:** No high-severity bandit hits or secrets flagged by gitleaks/semgrep in the scanned scope.
- **Dead code:** vulture/deadcode found few or no unused symbols in production modules.
- **Duplication:** jscpd duplication is low (~3.8% duplication) for the scanned tree.
- **Refactoring:** Strict refactor scan found only ~0 opportunities — structure is relatively stable.

## What you could improve

- **Complexity:** radon flagged functions or modules above cyclomatic-complexity gates — consider incremental extraction.
- **Lint / style (~463 findings):** Many items are formatting or style rules — align fixes with your existing ruff/pyproject config.
- **Hotspot:** `tests/test_sonarr_series_folder_rename.py` concentrates the most findings — start there for incremental cleanup.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | ---: | --- | --- |
| `shipgate format` | 0 | timeout or non-zero exit | no |
| `tests` | 0 | FAILED: python -m pytest -q | yes |
| **Total** | **0** | *See autofix.log for details* | — |
