### PR TITLE
Add ty type validation

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -82,6 +82,29 @@ jobs:
       - name: Ruff format check
         run: uv run --no-sync ruff format --check .
 
+  ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518  # v4.2.5
+        with:
+          version: 2026.8.12
+          install_args: python
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Install type-check dependencies
+        run: uv sync --locked --group dev --group test
+
+      - name: Type check with ty
+        run: uv run --no-sync ty check --output-format=github .
+
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,10 @@ repos:
         args:
           - --fix
       - id: ruff-format
-  # - repo: https://github.com/astral-sh/ty-pre-commit
-  #   rev: v0.0.66
-  #   hooks:
-  #     - id: ty
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.74
+    hooks:
+      - id: ty
   - repo: https://github.com/hadolint/hadolint
     rev: v2.15.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "ruff==0.16.4",
+  "ty==0.0.74",
 ]
 test = [
   "pytest>=9.0.1,<10",

--- a/renovate.json
+++ b/renovate.json
@@ -14,15 +14,18 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "astral-sh/ty-pre-commit",
         "astral-sh/uv",
         "astral-sh/uv-pre-commit",
         "ghcr.io/astral-sh/uv",
-        "ty",
         "uv"
       ],
       "groupName": "uv",
       "minimumGroupSize": 2
+    },
+    {
+      "matchDepNames": ["ty", "astral-sh/ty-pre-commit"],
+      "groupName": "ty",
+      "minimumGroupSize": 3
     },
     {
       "matchPackageNames": ["ruff", "astral-sh/ruff-pre-commit"],

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -20,16 +20,32 @@ def minimal_instance_config() -> dict[str, str]:
     }
 
 
-def _renamarr_config(
+def _instance_config(
     validated: dict[str, object], service: str, instance_index: int = 0
 ) -> dict[str, object]:
     service_configs = validated[service]
     assert isinstance(service_configs, list)
     instance_config = service_configs[instance_index]
     assert isinstance(instance_config, dict)
+    return instance_config
+
+
+def _renamarr_config(
+    validated: dict[str, object], service: str, instance_index: int = 0
+) -> dict[str, object]:
+    instance_config = _instance_config(validated, service, instance_index)
     renamarr_config = instance_config["renamarr"]
     assert isinstance(renamarr_config, dict)
     return renamarr_config
+
+
+def _schedule_config(
+    validated: dict[str, object], service: str, instance_index: int = 0
+) -> dict[str, object]:
+    renamarr_config = _renamarr_config(validated, service, instance_index)
+    schedule_config = renamarr_config["schedule"]
+    assert isinstance(schedule_config, dict)
+    return schedule_config
 
 
 def test_omitted_services_default_to_empty_lists() -> None:
@@ -179,15 +195,17 @@ def test_extra_service_and_nested_keys_are_ignored() -> None:
         }
     )
 
-    sonarr_config = validated["sonarr"][0]
-    radarr_config = validated["radarr"][0]
+    sonarr_config = _instance_config(validated, "sonarr")
+    radarr_config = _instance_config(validated, "radarr")
+    sonarr_renamarr = _renamarr_config(validated, "sonarr")
+    radarr_renamarr = _renamarr_config(validated, "radarr")
 
     assert "unexpected" not in sonarr_config
-    assert "unexpected" not in sonarr_config["renamarr"]
+    assert "unexpected" not in sonarr_renamarr
     assert "unexpected" not in radarr_config
-    assert "unexpected" not in radarr_config["renamarr"]
-    assert sonarr_config["renamarr"]["rename_folders"] is True
-    assert radarr_config["renamarr"]["analyze_files"] is True
+    assert "unexpected" not in radarr_renamarr
+    assert sonarr_renamarr["rename_folders"] is True
+    assert radarr_renamarr["analyze_files"] is True
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
@@ -241,7 +259,7 @@ def test_schedule_interval_is_validated(
 
     validated = validate_config({service: [instance_config]})
 
-    assert validated[service][0]["renamarr"]["schedule"] == {
+    assert _schedule_config(validated, service) == {
         "enabled": True,
         "interval": expected,
     }
@@ -260,9 +278,7 @@ def test_disabled_schedule_accepts_zero_interval(service: str) -> None:
 
     validated = validate_config({service: [instance_config]})
 
-    assert validated[service][0]["renamarr"]["schedule"]["interval"] == Interval(
-        0, 0, 0
-    )
+    assert _schedule_config(validated, service)["interval"] == Interval(0, 0, 0)
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])
@@ -276,8 +292,8 @@ def test_deprecated_hourly_job_sets_schedule_enabled_without_parse_warning(
 
     validated = validate_config({service: [instance_config]})
 
-    assert validated[service][0]["renamarr"]["hourly_job"] is hourly_job
-    assert validated[service][0]["renamarr"]["schedule"]["enabled"] is hourly_job
+    assert _renamarr_config(validated, service)["hourly_job"] is hourly_job
+    assert _schedule_config(validated, service)["enabled"] is hourly_job
     mock_loguru_warning.assert_not_called()
 
 
@@ -294,7 +310,7 @@ def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
 
     validated = validate_config({service: [instance_config]})
 
-    assert validated[service][0]["renamarr"]["schedule"] == {
+    assert _schedule_config(validated, service) == {
         "enabled": False,
         "interval": Interval(days=0, hours=0, minutes=30),
     }
@@ -317,7 +333,7 @@ def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
 
     validated = validate_config({service: [instance_config]})
 
-    assert validated[service][0]["renamarr"]["schedule"]["enabled"] is schedule_enabled
+    assert _schedule_config(validated, service)["enabled"] is schedule_enabled
 
 
 @pytest.mark.parametrize("service", ["sonarr", "radarr"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import Iterator
 from contextlib import nullcontext
 from pathlib import Path
+from typing import Protocol
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,6 +21,37 @@ from renamarr.protocols import ArrAdapter
 
 # disable config caching
 configparser.hold_an_instance = False
+
+
+class _IntervalConfig(Protocol):
+    total_minutes: int
+
+
+class _ScheduleConfig(Protocol):
+    enabled: bool
+    interval: _IntervalConfig
+
+
+class _RenamarrConfig(Protocol):
+    enabled: bool
+    hourly_job: bool
+    analyze_files: bool
+    rename_folders: bool
+    schedule: _ScheduleConfig
+    command_polling: CommandPollingSettings
+
+
+class _ServiceConfig(Protocol):
+    name: str
+    url: str
+    api_key: str
+    renamarr: _RenamarrConfig
+
+
+def _service_config(
+    config: Config, service: str, instance_index: int = 0
+) -> _ServiceConfig:
+    return getattr(config, service)[instance_index]
 
 
 class TestMain:
@@ -244,7 +276,7 @@ class TestMain:
         mock_loguru_warning: MagicMock,
         mocker: MockerFixture,
     ) -> None:
-        service_config = config.sonarr[0]
+        service_config = _service_config(config, "sonarr")
         service_config.renamarr.enabled = True
         service_config.renamarr.hourly_job = True
         mocker.patch("pyconfigparser.configparser.get_config", return_value=config)
@@ -366,10 +398,10 @@ class TestMain:
         self, config: Config, mocker: MockerFixture
     ) -> None:
         enabled_instances = [
-            (ArrService.SONARR, config.sonarr[0]),
-            (ArrService.SONARR, config.sonarr[1]),
-            (ArrService.RADARR, config.radarr[0]),
-            (ArrService.RADARR, config.radarr[1]),
+            (ArrService.SONARR, _service_config(config, "sonarr")),
+            (ArrService.SONARR, _service_config(config, "sonarr", 1)),
+            (ArrService.RADARR, _service_config(config, "radarr")),
+            (ArrService.RADARR, _service_config(config, "radarr", 1)),
         ]
         for _, instance_config in enabled_instances:
             instance_config.renamarr.enabled = True
@@ -412,8 +444,9 @@ class TestMain:
     def test_external_cron_does_not_disable_explicit_renamarr_schedule(
         self, config: Config, mocker: MockerFixture
     ) -> None:
-        config.radarr[0].renamarr.enabled = True
-        config.radarr[0].renamarr.schedule.enabled = True
+        service_config = _service_config(config, "radarr")
+        service_config.renamarr.enabled = True
+        service_config.renamarr.schedule.enabled = True
         mocker.patch.dict(os.environ, {"EXTERNAL_CRON": "TRUE"})
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
         renamarr = mocker.patch("main.Renamarr")

--- a/uv.lock
+++ b/uv.lock
@@ -309,6 +309,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
+    { name = "ty" },
 ]
 test = [
     { name = "pytest" },
@@ -328,7 +329,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = "==0.16.4" }]
+dev = [
+    { name = "ruff", specifier = "==0.16.4" },
+    { name = "ty", specifier = "==0.0.74" },
+]
 test = [
     { name = "pytest", specifier = ">=9.0.1,<10" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8" },
@@ -394,6 +398,28 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
     { name = "urllib3" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.74"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/0f/c767853e88567a2ec7e996dd95e3105b1bc62c95d103689311ef0f4a603c/ty-0.0.74.tar.gz", hash = "sha256:da14344fc8625fc9ff359bafb856ad575636ea86d9bb6a629b146bff27b380e6", size = 6786318, upload-time = "2026-08-22T15:05:54.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/95/6ded58bc97885c6d88fa1f9cd815031489200738f961cbf0466663213f80/ty-0.0.74-py3-none-linux_armv6l.whl", hash = "sha256:8969ef4e508debf00cf58f9ea85a539f799b1732c59cdfcecd037630b9755b30", size = 12790043, upload-time = "2026-08-22T15:05:05.015Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8a/5e323603b6ab8731144421877ee8a0f8ac5a5511e67857127caa09f6730e/ty-0.0.74-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51fb6cf5b98e1e1140825b2430943f78d744876a735231656eafbb4c3f7eca3c", size = 12371748, upload-time = "2026-08-22T15:05:08.609Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/ee72e08cb705281e8d8c42917dd577aa598a8a098008495fda5176ee3f6e/ty-0.0.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ebe60b1f0a948c793d6c77fc9e9ddda599e4f023c04ab16e8e03bcb428c3fa0", size = 12282403, upload-time = "2026-08-22T15:05:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b3/fd935b694ff68bc278af50f7ad04770b36ce6306399baef7e1847b553a9d/ty-0.0.74-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa97f407a695c890a53615966a663c7d2167e2cabe88db7ca1a24d62635cdfc8", size = 12345164, upload-time = "2026-08-22T15:05:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5c/5b5825268e029ebb164c909780103dbbae367f069801410068bf1cef29b3/ty-0.0.74-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:673ddb733d4a0db31385ba1ed9ff1f6bd9dc5565413ce57b1ca5ac4c7803da5d", size = 12556646, upload-time = "2026-08-22T15:05:16.994Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e7/515914e571d62ce0101744fed3f881936eeb1b30dc37beb72b4f7ca1e289/ty-0.0.74-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1028e7c6b4f6145e9704552f43a5fffdcd51b42263ffdcd9c9677762bc395a4a", size = 13311653, upload-time = "2026-08-22T15:05:20.254Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/07/d1452babb6f9266c2122cabc095180b70ed306fb770b2996753814d2237d/ty-0.0.74-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79841a8890493021fb308772474983316eb91f7b56cb227a6a05a06b262a36f0", size = 13768284, upload-time = "2026-08-22T15:05:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/60/8d4a2fc7842a47210a1cb0a16a187d9de39ad5d509a00fb74c1c073afcde/ty-0.0.74-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94859d321f3c6a6c8f7bfc3f40e8319cda7e6e012e613440f3dfd145d5010e2e", size = 13422306, upload-time = "2026-08-22T15:05:26.248Z" },
+    { url = "https://files.pythonhosted.org/packages/de/76/ebbc269a8c4efcc4d44624993bd188145f20d60ebda9680b15aaec42cc50/ty-0.0.74-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:970a8b2c09ff3be04c8a1c6767332d861be4fce85efe7bb205e4ade7c8655274", size = 12970637, upload-time = "2026-08-22T15:05:29.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/dd/b99f7236acbf856780ca1779a48143d2d9f2c24d7f531a0ce15a022b8a87/ty-0.0.74-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:795f763b3ded85574c2c2846a6fb8acf2aa76e9e83d761143e92b1f0c7ffa2cd", size = 13344891, upload-time = "2026-08-22T15:05:32.033Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/9ff7449a4c7e6428f2c6f298e74cf24b70668f29d45c249507a723ff3782/ty-0.0.74-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dc086db5367d912c31c0cc872deb7387290e779a4b9b54fcb944673a7cd52c7b", size = 12395272, upload-time = "2026-08-22T15:05:34.702Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/dd/b23a5b6b35d37df89dc8dc5daa09efd9245a668b50c4c81c25de21567dc1/ty-0.0.74-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0314d7b391cf684e47c2fa093d2ce4c597cfc9b01d9a315fe204aed6359b271b", size = 12573079, upload-time = "2026-08-22T15:05:37.683Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c5/ccba16239d6129533c8b3603458d0f4dd2ba69478e47059073968e74261d/ty-0.0.74-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4a45dd2e991e8bdae82ba78c8cd051b253f60bc71a6536598fa3ef580b4fc9b", size = 12832506, upload-time = "2026-08-22T15:05:40.505Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1c/2390912634dff4f341f97b397f2aee341ff062be0a66cda37d59375454f2/ty-0.0.74-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:210e2eac6b018fb934e2b8dac3956a0ba076a3fb1fa6f135058c825e5b759b81", size = 13154752, upload-time = "2026-08-22T15:05:43.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add pinned ty checks to Python CI and pre-commit
- keep ty versions synchronized across uv, mise, and pre-commit with Renovate
- model dynamic test configuration boundaries so ty passes without casts or suppressions

## Testing

- uv run ty check .
- uv run pytest (303 passed, 100% coverage)
- prek run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated static type checking to continuous integration and pre-commit checks.
  * Included the type-checking tool in development setup and organized its automated updates separately.

* **Tests**
  * Improved test configuration helpers and typing for clearer, more maintainable test coverage.
  * Preserved existing configuration-schema and service behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->