### PR TITLE
Create lidarr adapter and config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each invocation runs every enabled job once and exits without restarting when no
 2. Update `config.yml` as needed
    - _Set `sonarr[].renamarr.schedule.enabled` to `false` for every enabled Renamarr instance._
    - _Set `radarr[].renamarr.schedule.enabled` to `false` for every enabled Renamarr instance._
+   - _Set `lidarr[].renamarr.schedule.enabled` to `false` for every enabled Renamarr instance._
 3. Invoke the app from your scheduler using the provided [docker-compose.yml](example/external-scheduler/docker-compose.yml)
 
 #### Troubleshooting
@@ -33,25 +34,27 @@ Image tags ending in `-dev` can be used for troubleshooting purposes, but are no
 
 ### Renamarr
 
-This job uses the [Sonarr API](https://sonarr.tv/docs/api/)/[Radarr API](https://radarr.video/docs/api/) to do the following
+This job uses the [Sonarr API](https://sonarr.tv/docs/api/), [Radarr API](https://radarr.video/docs/api/), and [Lidarr API](https://github.com/devopsarr/lidarr-py#documentation-for-api-endpoints) to do the following
 
-Sonarr API access uses [devopsarr/sonarr-py](https://github.com/devopsarr/sonarr-py), and Radarr API access uses [devopsarr/radarr-py](https://github.com/devopsarr/radarr-py). Existing Sonarr and Radarr configuration remains unchanged.
+Sonarr API access uses [devopsarr/sonarr-py](https://github.com/devopsarr/sonarr-py), Radarr API access uses [devopsarr/radarr-py](https://github.com/devopsarr/radarr-py), and Lidarr API access uses [devopsarr/lidarr-py](https://github.com/devopsarr/lidarr-py). Existing Arr configuration remains unchanged.
 
-- Iterate over all items (Movies or Series)
+- Iterate over all items (Movies, Series, or Artists)
   - Checks if any items need to be renamed
     - Radarr [get_api_v3_rename](https://radarr.video/docs/api/#/RenameMovie/get_api_v3_rename)
     - Sonarr [get_api_v3_rename](https://sonarr.tv/docs/api/#/RenameEpisode/get_api_v3_rename)
+    - Lidarr [list_rename](https://github.com/devopsarr/lidarr-py/blob/v1.2.1/docs/RenameTrackApi.md)
   - Triggers a rename on any item that need be renamed
     - Series renames are batched up, for one rename call per series
     - Movie renames are discovered per movie, then initiated in one batch command with all movie IDs that need a rename
+    - Track renames are batched up, for one rename call per artist
 
 #### Analyze Files
 
-This config option is useful if you have audio/video codec information as part of your mediaformat, and you are transcoding files after import. This will initiate a rescan of the files in your library, so that the mediainfo will be updated. Then renamarr will come through and detect changes, and rename the files
+This config option is useful if you have audio/video codec information as part of your mediaformat, and you are transcoding files after import. This will initiate a rescan of the files in your library, so that the mediainfo will be updated. Then renamarr will come through and detect changes, and rename the files. Lidarr uses a direct `RescanFolders` command with discovery of new artists disabled.
 
 #### Rename Folders
 
-This config option will rename series or movie folders when they no longer match your configured MediaFormat.
+This config option will rename series, movie, or artist folders when they no longer match your configured MediaFormat.
 
 - uses [/api/v3/series/{id}/folder](https://sonarr.tv/docs/api/#/SeriesFolder/get_api_v3_series__id__folder) endpoint to determine if the series folder requires an update
 - uses [/api/v3/series/editor](https://sonarr.tv/docs/api/#v3/tag/serieseditor/PUT/api/v3/series/editor) endpoint to update series rootFolderPath to it's current value
@@ -59,9 +62,13 @@ This config option will rename series or movie folders when they no longer match
 - uses [/api/v3/movie/{id}/folder](https://radarr.video/docs/api/#/MovieFolder/get_api_v3_movie__id__folder) endpoint to determine if the movie folder requires an update
 - uses [/api/v3/movie/editor](https://radarr.video/docs/api/#/MovieEditor/put_api_v3_movie_editor) endpoint to update movie rootFolderPath to it's current value
   - moving the folder in place
+- uses Lidarr's [`/api/v1/artist/lookup`](https://github.com/devopsarr/lidarr-py/blob/v1.2.1/docs/ArtistLookupApi.md) endpoint to determine the expected artist folder
+- uses Lidarr's [`/api/v1/artist/editor`](https://github.com/devopsarr/lidarr-py/blob/v1.2.1/docs/ArtistEditorApi.md) endpoint to update artist rootFolderPath to its current value
+  - moving the artist folder in place; album-directory changes remain part of the track rename workflow
 - sends a Sonarr `RescanSeries` command to rescan series after successful folder moves
 - sends a Radarr `RefreshMovie` command to rescan movies after successful folder moves
-- Series and movies are processed in bulk at the end of the run, **per root folder**
+- sends a Lidarr `RescanFolders` command to rescan artists after successful folder moves
+- Series, movies, and artists are processed in bulk at the end of the run, **per root folder**
 
 #### Command Polling and Partial Results
 
@@ -85,12 +92,13 @@ Failed runs report the same totals at `ERROR` level after their individual error
 
 ### File Logging
 
-Set `sonarr[].renamarr.log_to_file` or `radarr[].renamarr.log_to_file` to `true` to enable per-instance log files. If the target log path is not writable, renamarr logs a warning to stdout and continues running without logging to file.
+Set `sonarr[].renamarr.log_to_file`, `radarr[].renamarr.log_to_file`, or `lidarr[].renamarr.log_to_file` to `true` to enable per-instance log files. If the target log path is not writable, renamarr logs a warning to stdout and continues running without logging to file.
 
 When enabled, logs for that instance are written under `LOG_DIR` (`/logs` by default) using one of these paths:
 
 - `sonarr/<name>.log`
 - `radarr/<name>.log`
+- `lidarr/<name>.log`
 
 _Don't forget to mount /logs outside the container to persist log files_
 
@@ -141,6 +149,21 @@ _For more details on `LOG_RETENTION` or `LOG_ROTATION` values, see the [official
 | `radarr[].renamarr.log_to_file`                            | boolean | No       | False         | writes logs for this Radarr instance to `LOG_DIR/radarr/<name>.log` with daily rotation                                                          |
 | `radarr[].renamarr.command_polling.timeout_seconds`        | integer | No       | 120           | maximum time to wait for each analysis, rename, or rescan command                                                                                |
 | `radarr[].renamarr.command_polling.check_interval_seconds` | integer | No       | 3             | seconds between command-status checks after the immediate first check                                                                            |
+| `lidarr`                                                   | Array   | No       | []            | Lidarr instances; when present, must contain at least one instance                                                                               |
+| `lidarr[].name`                                            | string  | Yes      | N/A           | user friendly instance name, used in log messages                                                                                                |
+| `lidarr[].url`                                             | string  | Yes      | N/A           | url for lidarr instance                                                                                                                          |
+| `lidarr[].api_key`                                         | string  | Yes      | N/A           | api_key for lidarr instance                                                                                                                      |
+| `lidarr[].renamarr.enabled`                                | boolean | No       | False         | enables/disables renamarr functionality                                                                                                          |
+| `lidarr[].renamarr.hourly_job`                             | boolean | No       | N/A           | **Deprecated:** compatibility alias for `schedule.enabled`; an explicit `schedule.enabled` takes precedence                                      |
+| `lidarr[].renamarr.schedule.enabled`                       | boolean | No       | True          | enables recurring Renamarr jobs; when false, Renamarr runs once at startup                                                                       |
+| `lidarr[].renamarr.schedule.interval.days`                 | integer | No       | 0             | days between Renamarr jobs                                                                                                                       |
+| `lidarr[].renamarr.schedule.interval.hours`                | integer | No       | 0             | hours between Renamarr jobs                                                                                                                      |
+| `lidarr[].renamarr.schedule.interval.minutes`              | integer | No       | 0             | minutes between Renamarr jobs                                                                                                                    |
+| `lidarr[].renamarr.analyze_files`                          | boolean | No       | False         | This will initiate a rescan of the files in your library. This is helpful if you are transcoding files, and the audio codecs have changed.       |
+| `lidarr[].renamarr.rename_folders`                         | boolean | No       | False         | This will rename artist folders when the current artist folder no longer matches your MediaFormat                                                |
+| `lidarr[].renamarr.log_to_file`                            | boolean | No       | False         | writes logs for this Lidarr instance to `LOG_DIR/lidarr/<name>.log` with daily rotation                                                          |
+| `lidarr[].renamarr.command_polling.timeout_seconds`        | integer | No       | 120           | maximum time to wait for each analysis, rename, or rescan command                                                                                |
+| `lidarr[].renamarr.command_polling.check_interval_seconds` | integer | No       | 3             | seconds between command-status checks after the immediate first check                                                                            |
 
 Schedule interval values must be non-negative integers, and the combined interval cannot exceed 30 days. When scheduling is enabled, the combined interval must be greater than zero. A zero interval is valid only when `schedule.enabled` is `false`.
 

--- a/example/config.yml.example
+++ b/example/config.yml.example
@@ -38,3 +38,14 @@ radarr:
           days: 1
           hours: 0
           minutes: 5
+lidarr:
+  - name: music
+    url: https://lidarr.tld:8686
+    api_key: not-a-real-api-key
+    renamarr:
+      enabled: true
+      analyze_files: false
+      rename_folders: true
+      log_to_file: true
+      schedule:
+        enabled: true

--- a/example/external-scheduler/config.yml.example
+++ b/example/external-scheduler/config.yml.example
@@ -20,3 +20,14 @@ radarr:
       log_to_file: false
       schedule:
         enabled: false
+lidarr:
+  - name: music
+    url: https://lidarr.tld:8686
+    api_key: not-a-real-api-key
+    renamarr:
+      enabled: true
+      analyze_files: false
+      rename_folders: true
+      log_to_file: true
+      schedule:
+        enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "sonarr",
   "pydantic>=2,<3",
   "radarr>=1.2.1",
+  "lidarr>=1.2.1",
 ]
 
 [dependency-groups]
@@ -38,6 +39,8 @@ environments = [
 [tool.uv.sources]
 sonarr = { git = "https://github.com/devopsarr/sonarr-py.git", tag = "v1.1.1" }
 radarr = { git = "https://github.com/devopsarr/radarr-py.git", tag = "v1.2.1" }
+lidarr = { git = "https://github.com/devopsarr/lidarr-py.git", tag = "v1.2.1" }
+
 
 [tool.ty.analysis]
 # These dependencies expose incomplete or overly broad type information.

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -127,75 +127,34 @@ RENAMARR_SCHEMA = And(
     ),
 )
 
+
+def _service_schema(service: str) -> And:
+    required_fields = {
+        field: And(
+            lambda value: value is not None,
+            Use(str),
+            lambda value: len(value) > 0,
+            error=f"{service}[].{field} is a required field",
+        )
+        for field in ("name", "url", "api_key")
+    }
+    return And(
+        lambda instances: len(instances),
+        [
+            required_fields
+            | {
+                Optional(
+                    "renamarr",
+                    default=_renamarr_defaults,
+                    ignore_extra_keys=True,
+                ): RENAMARR_SCHEMA,
+            }
+        ],
+        ignore_extra_keys=True,
+    )
+
+
 CONFIG_SCHEMA = {
-    Optional(
-        "sonarr",
-        default=[],
-        ignore_extra_keys=True,
-    ): And(
-        lambda n: len(n),
-        [
-            {
-                "name": And(
-                    lambda s: s is not None,
-                    Use(str),
-                    lambda s: len(s) > 0,
-                    error="sonarr[].name is a required field",
-                ),
-                "url": And(
-                    lambda s: s is not None,
-                    Use(str),
-                    lambda s: len(s) > 0,
-                    error="sonarr[].url is a required field",
-                ),
-                "api_key": And(
-                    lambda s: s is not None,
-                    Use(str),
-                    lambda s: len(s) > 0,
-                    error="sonarr[].api_key is a required field",
-                ),
-                Optional(
-                    "renamarr",
-                    default=_renamarr_defaults,
-                    ignore_extra_keys=True,
-                ): RENAMARR_SCHEMA,
-            }
-        ],
-        ignore_extra_keys=True,
-    ),
-    Optional(
-        "radarr",
-        default=[],
-        ignore_extra_keys=True,
-    ): And(
-        lambda n: len(n),
-        [
-            {
-                "name": And(
-                    lambda s: s is not None,
-                    Use(str),
-                    lambda s: len(s) > 0,
-                    error="radarr[].name is a required field",
-                ),
-                "url": And(
-                    lambda s: s is not None,
-                    Use(str),
-                    lambda s: len(s) > 0,
-                    error="radarr[].url is a required field",
-                ),
-                "api_key": And(
-                    lambda s: s is not None,
-                    Use(str),
-                    lambda s: len(s) > 0,
-                    error="radarr[].api_key is a required field",
-                ),
-                Optional(
-                    "renamarr",
-                    default=_renamarr_defaults,
-                    ignore_extra_keys=True,
-                ): RENAMARR_SCHEMA,
-            }
-        ],
-        ignore_extra_keys=True,
-    ),
+    Optional(service, default=[], ignore_extra_keys=True): _service_schema(service)
+    for service in ("sonarr", "radarr", "lidarr")
 }

--- a/src/main.py
+++ b/src/main.py
@@ -133,6 +133,7 @@ class Main:
         service_configs = (
             (ArrService.SONARR, config.sonarr),
             (ArrService.RADARR, config.radarr),
+            (ArrService.LIDARR, config.lidarr),
         )
         for service, configs in service_configs:
             instance_config: _ArrInstanceConfig

--- a/src/renamarr/adapter_factory.py
+++ b/src/renamarr/adapter_factory.py
@@ -1,5 +1,6 @@
 from enum import StrEnum
 
+from renamarr.lidarr.lidarr_adapter import LidarrAdapter
 from renamarr.protocols import ArrAdapter
 from renamarr.radarr.radarr_adapter import RadarrAdapter
 from renamarr.sonarr.sonarr_adapter import SonarrAdapter
@@ -8,6 +9,7 @@ from renamarr.sonarr.sonarr_adapter import SonarrAdapter
 class ArrService(StrEnum):
     """Arr services supported by Renamarr."""
 
+    LIDARR = "lidarr"
     RADARR = "radarr"
     SONARR = "sonarr"
 
@@ -15,6 +17,8 @@ class ArrService(StrEnum):
 def create_arr_adapter(service: ArrService, url: str, api_key: str) -> ArrAdapter:
     """Create the adapter for a supported Arr service."""
     match service:
+        case ArrService.LIDARR:
+            return LidarrAdapter(url, api_key)
         case ArrService.RADARR:
             return RadarrAdapter(url, api_key)
         case ArrService.SONARR:

--- a/src/renamarr/lidarr/lidarr_adapter.py
+++ b/src/renamarr/lidarr/lidarr_adapter.py
@@ -1,0 +1,296 @@
+from collections.abc import Sequence
+from pathlib import PurePosixPath
+
+from lidarr import (
+    ApiClient,
+    ArtistApi,
+    ArtistEditorApi,
+    ArtistEditorResource,
+    ArtistLookupApi,
+    ArtistResource,
+    CommandApi,
+    CommandPriority,
+    CommandResource,
+    Configuration,
+    RenameTrackApi,
+    RootFolderApi,
+)
+from lidarr import CommandResult as LidarrCommandResult
+from lidarr import CommandStatus as LidarrCommandStatus
+from lidarr.rest import ApiException
+from pydantic import Field
+
+from renamarr.adapter_helpers import require, translate_api_error
+from renamarr.models.command import CommandStatus
+from renamarr.models.media import (
+    FileRenameBatch,
+    FileRenameCandidate,
+    FolderRenameBatch,
+    MediaItem,
+)
+
+
+class _LidarrCommandResource(CommandResource):
+    """Add command-specific fields omitted from Lidarr's OpenAPI schema."""
+
+    artist_id: int | None = Field(default=None, alias="artistId")
+    artist_ids: list[int] | None = Field(default=None, alias="artistIds")
+    files: list[int] | None = None
+    folders: list[str] | None = None
+    filter: str | None = None
+    add_new_artists: bool | None = Field(default=None, alias="addNewArtists")
+
+
+def _command_id(response: CommandResource) -> int:
+    return require(response.id, "Expected a numeric command ID from Lidarr")
+
+
+class LidarrAdapter:
+    """Normalize lidarr-py's generated client for the Renamarr engine."""
+
+    def __init__(self, url: str, api_key: str) -> None:
+        configuration = Configuration(
+            host=url,
+            api_key={"X-Api-Key": api_key},
+        )
+        self._client = ApiClient(configuration)
+        self._artist_api = ArtistApi(self._client)
+        self._artist_lookup_api = ArtistLookupApi(self._client)
+        self._command_api = CommandApi(self._client)
+        self._rename_api = RenameTrackApi(self._client)
+        self._root_folder_api = RootFolderApi(self._client)
+        self._artist_editor_api = ArtistEditorApi(self._client)
+        self._artists: dict[int, ArtistResource] = {}
+        self._expected_folders: dict[int, str] = {}
+
+    def close(self) -> None:
+        """Release the generated client's HTTP connection pools."""
+        self._client.rest_client.pool_manager.clear()
+
+    def list_media_items(self) -> list[MediaItem]:
+        """Return the artists in the Lidarr library."""
+        artists = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "List",
+            "artists",
+            self._artist_api.list_artist,
+        )
+        if not isinstance(artists, list):
+            raise TypeError("Expected a list of artists from Lidarr")
+
+        items: list[MediaItem] = []
+        for artist in artists:
+            artist_id = require(artist.id, "Expected an artist ID from Lidarr")
+            self._artists[artist_id] = artist
+            items.append(
+                MediaItem(
+                    id=artist_id,
+                    title=require(
+                        artist.artist_name,
+                        "Expected an artist name from Lidarr",
+                    ),
+                    path=require(artist.path, "Expected an artist path from Lidarr"),
+                )
+            )
+        return items
+
+    def is_media_analysis_enabled(self) -> bool:
+        """Return True because Lidarr always supports direct folder rescans."""
+        return True
+
+    def start_media_analysis(self) -> int:
+        """Start a full Lidarr folder rescan and return its command ID."""
+        response = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Start",
+            "media analysis",
+            lambda: self._command_api.create_command(
+                _LidarrCommandResource(
+                    name="RescanFolders",
+                    priority=CommandPriority.HIGH,
+                    filter="known",
+                    add_new_artists=False,
+                )
+            ),
+        )
+        return _command_id(response)
+
+    def get_command_status(self, command_id: int) -> CommandStatus:
+        """Return the normalized state of a Lidarr command."""
+        response = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Read",
+            "command status",
+            lambda: self._command_api.get_command_by_id(command_id),
+        )
+        return CommandStatus(
+            completed=response.status is LidarrCommandStatus.COMPLETED,
+            successful=response.result is LidarrCommandResult.SUCCESSFUL,
+        )
+
+    def get_file_rename_candidate(self, item: MediaItem) -> FileRenameCandidate | None:
+        """Return a candidate containing Lidarr's track rename preview."""
+        response = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Preview",
+            f"file rename for {item.title}",
+            lambda: self._rename_api.list_rename(artist_id=item.id),
+        )
+        if not isinstance(response, list):
+            raise TypeError("Expected a list of rename previews from Lidarr")
+        if not response:
+            return None
+        return FileRenameCandidate(
+            item=item,
+            file_ids=tuple(
+                require(
+                    preview.track_file_id,
+                    "Expected a track file ID in Lidarr rename preview",
+                )
+                for preview in response
+            ),
+            description=item.title,
+        )
+
+    def build_file_rename_batches(
+        self, candidates: Sequence[FileRenameCandidate]
+    ) -> list[FileRenameBatch]:
+        """Build one Lidarr RenameFiles batch per artist."""
+        return [
+            FileRenameBatch(
+                item_ids=(candidate.item.id,),
+                file_ids=candidate.file_ids,
+                description=candidate.description,
+            )
+            for candidate in candidates
+        ]
+
+    def start_file_rename(self, batch: FileRenameBatch) -> int:
+        """Start a Lidarr RenameFiles command for one artist."""
+        response = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Start",
+            "file rename",
+            lambda: self._command_api.create_command(
+                _LidarrCommandResource(
+                    name="RenameFiles",
+                    artist_id=batch.item_ids[0],
+                    files=list(batch.file_ids),
+                )
+            ),
+        )
+        return _command_id(response)
+
+    def list_root_folders(self) -> list[str]:
+        """Return configured Lidarr root-folder paths."""
+        response = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "List",
+            "root folders",
+            self._root_folder_api.list_root_folder,
+        )
+        if not isinstance(response, list):
+            raise TypeError("Expected a list of root folders from Lidarr")
+        return [
+            require(root.path, "Expected a root-folder path from Lidarr")
+            for root in response
+        ]
+
+    def get_expected_folder_name(self, item: MediaItem) -> str:
+        """Return the folder name Lidarr expects for an artist."""
+        cached_folder = self._expected_folders.get(item.id)
+        if cached_folder is not None:
+            return cached_folder
+
+        artist = self._artists.get(item.id)
+        if artist is None:
+            artist = translate_api_error(
+                "Lidarr",
+                ApiException,
+                "Read",
+                f"artist {item.title}",
+                lambda: self._artist_api.get_artist_by_id(item.id),
+            )
+            self._artists[item.id] = artist
+
+        foreign_artist_id = require(
+            artist.foreign_artist_id,
+            "Expected a foreign artist ID from Lidarr",
+        )
+        lookup_results = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Resolve",
+            f"folder for {item.title}",
+            lambda: self._artist_lookup_api.list_artist_lookup(
+                term=f"lidarr:{foreign_artist_id}"
+            ),
+        )
+        if not isinstance(lookup_results, list):
+            raise TypeError("Expected a list of artist lookup results from Lidarr")
+        matching_artist = require(
+            next(
+                (
+                    lookup_artist
+                    for lookup_artist in lookup_results
+                    if lookup_artist.foreign_artist_id == foreign_artist_id
+                ),
+                None,
+            ),
+            "Expected an exact artist lookup result from Lidarr",
+        )
+        folder = require(
+            matching_artist.folder,
+            "Expected an artist folder from Lidarr",
+        )
+        self._expected_folders[item.id] = folder
+        return folder
+
+    def move_folder(self, batch: FolderRenameBatch) -> None:
+        """Move a batch of Lidarr artist folders through the public API."""
+        translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Move",
+            "artist folders",
+            lambda: self._artist_editor_api.put_artist_editor(
+                ArtistEditorResource(
+                    root_folder_path=batch.root_folder_path,
+                    artist_ids=list(batch.item_ids),
+                    move_files=batch.move_files,
+                )
+            ),
+        )
+
+    def start_folder_rescan(self, batch: FolderRenameBatch) -> int:
+        """Start a Lidarr rescan for artists whose folders moved."""
+        folders = [
+            str(
+                PurePosixPath(batch.root_folder_path)
+                / self.get_expected_folder_name(item)
+            )
+            for item in batch.items
+        ]
+        response = translate_api_error(
+            "Lidarr",
+            ApiException,
+            "Start",
+            "folder rescan",
+            lambda: self._command_api.create_command(
+                _LidarrCommandResource(
+                    name="RescanFolders",
+                    priority=CommandPriority.HIGH,
+                    artist_ids=list(batch.item_ids),
+                    folders=folders,
+                    filter="known",
+                    add_new_artists=False,
+                )
+            ),
+        )
+        return _command_id(response)

--- a/tests/fixtures/disabled.yml
+++ b/tests/fixtures/disabled.yml
@@ -21,3 +21,15 @@ radarr:
     api_key: radarr1-api-key
     renamarr:
       enabled: false
+
+lidarr:
+  - name: lidarr
+    url: https://lidarr.tld
+    api_key: lidarr-api-key
+    renamarr:
+      enabled: false
+  - name: lidarr1
+    url: https://lidarr1.tld
+    api_key: lidarr1-api-key
+    renamarr:
+      enabled: false

--- a/tests/test_adapter_factory.py
+++ b/tests/test_adapter_factory.py
@@ -5,6 +5,9 @@ from renamarr.adapter_factory import ArrService, create_arr_adapter
 
 
 def test_selects_radarr_adapter(mocker: MockerFixture) -> None:
+    lidarr_adapter = mocker.patch(
+        "renamarr.adapter_factory.LidarrAdapter", autospec=True
+    )
     radarr_adapter = mocker.patch(
         "renamarr.adapter_factory.RadarrAdapter", autospec=True
     )
@@ -16,11 +19,15 @@ def test_selects_radarr_adapter(mocker: MockerFixture) -> None:
         create_arr_adapter(ArrService.RADARR, "https://radarr.test", "radarr-key")
         is radarr_adapter.return_value
     )
+    lidarr_adapter.assert_not_called()
     radarr_adapter.assert_called_once_with("https://radarr.test", "radarr-key")
     sonarr_adapter.assert_not_called()
 
 
 def test_selects_sonarr_adapter(mocker: MockerFixture) -> None:
+    lidarr_adapter = mocker.patch(
+        "renamarr.adapter_factory.LidarrAdapter", autospec=True
+    )
     radarr_adapter = mocker.patch(
         "renamarr.adapter_factory.RadarrAdapter", autospec=True
     )
@@ -32,13 +39,34 @@ def test_selects_sonarr_adapter(mocker: MockerFixture) -> None:
         create_arr_adapter(ArrService.SONARR, "https://sonarr.test", "sonarr-key")
         is sonarr_adapter.return_value
     )
+    lidarr_adapter.assert_not_called()
     sonarr_adapter.assert_called_once_with("https://sonarr.test", "sonarr-key")
     radarr_adapter.assert_not_called()
 
 
+def test_selects_lidarr_adapter(mocker: MockerFixture) -> None:
+    lidarr_adapter = mocker.patch(
+        "renamarr.adapter_factory.LidarrAdapter", autospec=True
+    )
+    radarr_adapter = mocker.patch(
+        "renamarr.adapter_factory.RadarrAdapter", autospec=True
+    )
+    sonarr_adapter = mocker.patch(
+        "renamarr.adapter_factory.SonarrAdapter", autospec=True
+    )
+
+    assert (
+        create_arr_adapter(ArrService.LIDARR, "https://lidarr.test", "lidarr-key")
+        is lidarr_adapter.return_value
+    )
+    lidarr_adapter.assert_called_once_with("https://lidarr.test", "lidarr-key")
+    radarr_adapter.assert_not_called()
+    sonarr_adapter.assert_not_called()
+
+
 def test_rejects_unsupported_service_value() -> None:
-    with pytest.raises(ValueError, match="'lidarr' is not a valid ArrService"):
-        ArrService("lidarr")
+    with pytest.raises(ValueError, match="'prowlarr' is not a valid ArrService"):
+        ArrService("prowlarr")
 
 
 def test_factory_rejects_unsupported_future_service_member(

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -7,6 +7,8 @@ from config_schema import CONFIG_SCHEMA
 from interval import Interval
 from renamarr.models.command import CommandPollingSettings
 
+ARR_SERVICES = ("sonarr", "radarr", "lidarr")
+
 
 def validate_config(config: dict[str, object]) -> dict[str, object]:
     return Schema(CONFIG_SCHEMA).validate(config)
@@ -49,13 +51,14 @@ def _schedule_config(
 
 
 def test_omitted_services_default_to_empty_lists() -> None:
-    assert validate_config({}) == {"sonarr": [], "radarr": []}
+    assert validate_config({}) == {"sonarr": [], "radarr": [], "lidarr": []}
 
 
 def test_minimal_sonarr_config_receives_defaults() -> None:
     validated = validate_config({"sonarr": [minimal_instance_config()]})
 
     assert validated["radarr"] == []
+    assert validated["lidarr"] == []
     assert validated["sonarr"] == [
         {
             "name": "instance",
@@ -80,7 +83,33 @@ def test_minimal_radarr_config_receives_defaults() -> None:
     validated = validate_config({"radarr": [minimal_instance_config()]})
 
     assert validated["sonarr"] == []
+    assert validated["lidarr"] == []
     assert validated["radarr"] == [
+        {
+            "name": "instance",
+            "url": "https://instance.tld",
+            "api_key": "api-key",
+            "renamarr": {
+                "enabled": False,
+                "analyze_files": False,
+                "rename_folders": False,
+                "log_to_file": False,
+                "schedule": {
+                    "enabled": True,
+                    "interval": Interval(days=0, hours=1, minutes=0),
+                },
+                "command_polling": CommandPollingSettings(),
+            },
+        }
+    ]
+
+
+def test_minimal_lidarr_config_receives_defaults() -> None:
+    validated = validate_config({"lidarr": [minimal_instance_config()]})
+
+    assert validated["sonarr"] == []
+    assert validated["radarr"] == []
+    assert validated["lidarr"] == [
         {
             "name": "instance",
             "url": "https://instance.tld",
@@ -142,13 +171,13 @@ def test_partial_renamarr_schedule_defaults_are_independent_between_instances() 
     assert second_schedule["enabled"] is True
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 def test_present_empty_service_list_is_rejected(service: str) -> None:
     with pytest.raises(SchemaError):
         validate_config({service: []})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize("field", ["name", "url", "api_key"])
 def test_required_service_fields_reject_missing_values(
     service: str, field: str
@@ -160,7 +189,7 @@ def test_required_service_fields_reject_missing_values(
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize("field", ["name", "url", "api_key"])
 def test_required_service_fields_reject_empty_values(service: str, field: str) -> None:
     instance_config = minimal_instance_config() | {field: ""}
@@ -208,7 +237,7 @@ def test_extra_service_and_nested_keys_are_ignored() -> None:
     assert radarr_renamarr["analyze_files"] is True
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize(
     "renamarr_config",
     [
@@ -237,7 +266,7 @@ def test_boolean_fields_reject_non_bool_values(
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize(
     ("configured", "expected"),
     [
@@ -265,7 +294,7 @@ def test_schedule_interval_is_validated(
     }
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 def test_disabled_schedule_accepts_zero_interval(service: str) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
@@ -281,7 +310,7 @@ def test_disabled_schedule_accepts_zero_interval(service: str) -> None:
     assert _schedule_config(validated, service)["interval"] == Interval(0, 0, 0)
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize("hourly_job", [True, False])
 def test_deprecated_hourly_job_sets_schedule_enabled_without_parse_warning(
     service: str, hourly_job: bool, mock_loguru_warning: MagicMock
@@ -297,7 +326,7 @@ def test_deprecated_hourly_job_sets_schedule_enabled_without_parse_warning(
     mock_loguru_warning.assert_not_called()
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
     service: str,
 ) -> None:
@@ -316,7 +345,7 @@ def test_deprecated_hourly_job_sets_enabled_on_custom_schedule(
     }
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize(
     ("hourly_job", "schedule_enabled"),
     [(False, True), (True, False)],
@@ -336,7 +365,7 @@ def test_schedule_enabled_takes_precedence_over_deprecated_hourly_job(
     assert _schedule_config(validated, service)["enabled"] is schedule_enabled
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize("schedule", [None, "hourly"])
 def test_deprecated_hourly_job_does_not_hide_invalid_schedule(
     service: str, schedule: object
@@ -349,7 +378,7 @@ def test_deprecated_hourly_job_does_not_hide_invalid_schedule(
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize(
     "interval",
     [
@@ -373,7 +402,7 @@ def test_schedule_rejects_intervals_over_thirty_days(
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 def test_enabled_schedule_rejects_zero_interval(service: str) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {
@@ -394,7 +423,7 @@ def test_enabled_schedule_rejects_zero_interval(service: str) -> None:
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -419,7 +448,7 @@ def test_schedule_rejects_invalid_interval_components_when_disabled(
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 def test_omitted_command_polling_receives_defaults(service: str) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {"enabled": True}
@@ -433,7 +462,7 @@ def test_omitted_command_polling_receives_defaults(service: str) -> None:
     )
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize(
     ("configured", "expected"),
     [
@@ -474,7 +503,7 @@ def test_command_polling_is_validated(
     assert renamarr_config["command_polling"] == expected
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 @pytest.mark.parametrize("field", ["timeout_seconds", "check_interval_seconds"])
 @pytest.mark.parametrize("value", [0, -1, True, False, 1.5, "1"])
 def test_command_polling_rejects_invalid_integer_values(
@@ -488,7 +517,7 @@ def test_command_polling_rejects_invalid_integer_values(
         validate_config({service: [instance_config]})
 
 
-@pytest.mark.parametrize("service", ["sonarr", "radarr"])
+@pytest.mark.parametrize("service", ARR_SERVICES)
 def test_command_polling_rejects_check_interval_over_timeout(service: str) -> None:
     instance_config: dict[str, object] = minimal_instance_config() | {
         "renamarr": {

--- a/tests/test_lidarr_adapter_contract.py
+++ b/tests/test_lidarr_adapter_contract.py
@@ -1,0 +1,470 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+from lidarr import (
+    ArtistEditorResource,
+    ArtistResource,
+    CommandResource,
+    RenameTrackResource,
+    RootFolderResource,
+)
+from lidarr import CommandResult as LidarrCommandResult
+from lidarr import CommandStatus as LidarrCommandStatus
+from lidarr.rest import ApiException
+from pytest_mock import MockerFixture
+
+from renamarr.exceptions import ArrOperationError
+from renamarr.lidarr.lidarr_adapter import LidarrAdapter
+from renamarr.models.command import CommandStatus
+from renamarr.models.media import (
+    FileRenameBatch,
+    FileRenameCandidate,
+    FolderRenameBatch,
+    MediaItem,
+)
+
+
+@pytest.fixture
+def lidarr_apis(mocker: MockerFixture) -> dict[str, MagicMock]:
+    mocker.patch("renamarr.lidarr.lidarr_adapter.ApiClient", autospec=True)
+    return {
+        name: mocker.patch(
+            f"renamarr.lidarr.lidarr_adapter.{name}", autospec=True
+        ).return_value
+        for name in (
+            "ArtistApi",
+            "ArtistLookupApi",
+            "CommandApi",
+            "RenameTrackApi",
+            "RootFolderApi",
+            "ArtistEditorApi",
+        )
+    }
+
+
+def test_wires_generated_lidarr_client(mocker: MockerFixture) -> None:
+    configuration = mocker.patch(
+        "renamarr.lidarr.lidarr_adapter.Configuration", autospec=True
+    )
+    api_client = mocker.patch("renamarr.lidarr.lidarr_adapter.ApiClient", autospec=True)
+    pool_manager = mocker.Mock()
+    api_client.return_value.rest_client = mocker.Mock(pool_manager=pool_manager)
+    api_classes = [
+        mocker.patch(f"renamarr.lidarr.lidarr_adapter.{name}", autospec=True)
+        for name in (
+            "ArtistApi",
+            "ArtistLookupApi",
+            "CommandApi",
+            "RenameTrackApi",
+            "RootFolderApi",
+            "ArtistEditorApi",
+        )
+    ]
+
+    adapter = LidarrAdapter("https://lidarr.test", "lidarr-key")
+
+    configuration.assert_called_once_with(
+        host="https://lidarr.test",
+        api_key={"X-Api-Key": "lidarr-key"},
+    )
+    api_client.assert_called_once_with(configuration.return_value)
+    assert adapter._client is api_client.return_value
+    for api_class in api_classes:
+        api_class.assert_called_once_with(api_client.return_value)
+
+    adapter.close()
+
+    pool_manager.clear.assert_called_once_with()
+
+
+@pytest.fixture
+def adapter(lidarr_apis: dict[str, MagicMock]) -> LidarrAdapter:
+    return LidarrAdapter("https://lidarr.test", "api-key")
+
+
+def test_maps_artists_to_shared_media_items(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    artist_api = lidarr_apis["ArtistApi"]
+    artist_api.list_artist.return_value = [
+        ArtistResource(
+            id=2,
+            artist_name="Artist B",
+            path="/music/Artist B",
+            foreign_artist_id="artist-b-id",
+        ),
+        ArtistResource(
+            id=1,
+            artist_name="Artist A",
+            path="/music/Artist A",
+            foreign_artist_id="artist-a-id",
+        ),
+    ]
+
+    assert adapter.list_media_items() == [
+        MediaItem(id=2, title="Artist B", path="/music/Artist B"),
+        MediaItem(id=1, title="Artist A", path="/music/Artist A"),
+    ]
+    artist_api.list_artist.assert_called_once_with()
+
+
+def test_media_analysis_is_always_available_and_starts_folder_rescan(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    command_api = lidarr_apis["CommandApi"]
+    command_api.create_command.return_value = CommandResource(id=17)
+
+    assert adapter.is_media_analysis_enabled() is True
+    assert adapter.start_media_analysis() == 17
+    command_api.create_command.assert_called_once()
+    command = command_api.create_command.call_args.args[0]
+    assert command.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "name": "RescanFolders",
+        "priority": "high",
+        "filter": "known",
+        "addNewArtists": False,
+    }
+
+
+def test_maps_command_status(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    command_api = lidarr_apis["CommandApi"]
+    command_api.get_command_by_id.side_effect = [
+        CommandResource(status=LidarrCommandStatus.STARTED),
+        CommandResource(
+            status=LidarrCommandStatus.COMPLETED,
+            result=LidarrCommandResult.UNSUCCESSFUL,
+        ),
+        CommandResource(
+            status=LidarrCommandStatus.COMPLETED,
+            result=LidarrCommandResult.SUCCESSFUL,
+        ),
+    ]
+
+    assert adapter.get_command_status(17) == CommandStatus(False, False)
+    assert adapter.get_command_status(17) == CommandStatus(True, False)
+    assert adapter.get_command_status(17) == CommandStatus(True, True)
+    assert command_api.get_command_by_id.call_args_list == [
+        call(17),
+        call(17),
+        call(17),
+    ]
+
+
+def test_maps_track_rename_previews_and_builds_per_artist_batches(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    artist_a = MediaItem(1, "Artist A", "/music/Artist A")
+    artist_b = MediaItem(2, "Artist B", "/music/Artist B")
+    rename_api = lidarr_apis["RenameTrackApi"]
+    rename_api.list_rename.side_effect = [
+        [],
+        [
+            RenameTrackResource(track_file_id=10),
+            RenameTrackResource(track_file_id=20),
+        ],
+    ]
+
+    assert adapter.get_file_rename_candidate(artist_a) is None
+    candidate_b = adapter.get_file_rename_candidate(artist_b)
+    assert candidate_b == FileRenameCandidate(
+        artist_b,
+        (10, 20),
+        "Artist B",
+    )
+    artist_c = MediaItem(3, "Artist C", "/music/Artist C")
+    candidate_c = FileRenameCandidate(artist_c, (30,), "Artist C")
+    assert adapter.build_file_rename_batches((candidate_b, candidate_c)) == [
+        FileRenameBatch((2,), (10, 20), "Artist B"),
+        FileRenameBatch((3,), (30,), "Artist C"),
+    ]
+    assert adapter.build_file_rename_batches(()) == []
+    assert rename_api.list_rename.call_args_list == [
+        call(artist_id=1),
+        call(artist_id=2),
+    ]
+
+
+def test_starts_artist_file_rename(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    batch = FileRenameBatch((7,), (10, 20), "Artist")
+    command_api = lidarr_apis["CommandApi"]
+    command_api.create_command.return_value = CommandResource(id=23)
+
+    assert adapter.start_file_rename(batch) == 23
+    command_api.create_command.assert_called_once()
+    command = command_api.create_command.call_args.args[0]
+    assert command.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "name": "RenameFiles",
+        "artistId": 7,
+        "files": [10, 20],
+    }
+
+
+def test_uses_lidarr_folder_endpoints_and_caches_expected_folders(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    artist = MediaItem(1, "Artist", "/music/Old Artist")
+    artist_api = lidarr_apis["ArtistApi"]
+    artist_api.list_artist.return_value = [
+        ArtistResource(
+            id=1,
+            artist_name="Artist",
+            path="/music/Old Artist",
+            foreign_artist_id="artist-id",
+        )
+    ]
+    root_folder_api = lidarr_apis["RootFolderApi"]
+    root_folder_api.list_root_folder.return_value = [
+        RootFolderResource(path="/music"),
+        RootFolderResource(path="/music-lossless"),
+    ]
+    artist_lookup_api = lidarr_apis["ArtistLookupApi"]
+    artist_lookup_api.list_artist_lookup.return_value = [
+        ArtistResource(foreign_artist_id="other-id", folder="Other Artist"),
+        ArtistResource(foreign_artist_id="artist-id", folder="A/Artist (2026)"),
+    ]
+    command_api = lidarr_apis["CommandApi"]
+    command_api.create_command.return_value = CommandResource(id=29)
+    batch = FolderRenameBatch("/music", (artist,), False)
+
+    adapter.list_media_items()
+    assert adapter.list_root_folders() == ["/music", "/music-lossless"]
+    assert adapter.get_expected_folder_name(artist) == "A/Artist (2026)"
+    assert adapter.get_expected_folder_name(artist) == "A/Artist (2026)"
+    assert adapter.move_folder(batch) is None
+    assert adapter.start_folder_rescan(batch) == 29
+
+    artist_lookup_api.list_artist_lookup.assert_called_once_with(
+        term="lidarr:artist-id"
+    )
+    artist_api.get_artist_by_id.assert_not_called()
+    root_folder_api.list_root_folder.assert_called_once_with()
+    artist_editor_api = lidarr_apis["ArtistEditorApi"]
+    artist_editor_api.put_artist_editor.assert_called_once()
+    editor = artist_editor_api.put_artist_editor.call_args.args[0]
+    assert isinstance(editor, ArtistEditorResource)
+    assert editor.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "artistIds": [1],
+        "rootFolderPath": "/music",
+        "moveFiles": False,
+    }
+    command_api.create_command.assert_called_once()
+    command = command_api.create_command.call_args.args[0]
+    assert command.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+        "name": "RescanFolders",
+        "priority": "high",
+        "artistIds": [1],
+        "folders": ["/music/A/Artist (2026)"],
+        "filter": "known",
+        "addNewArtists": False,
+    }
+
+
+def test_fetches_artist_when_folder_cache_was_not_seeded(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    item = MediaItem(7, "Artist", "/music/Artist")
+    lidarr_apis["ArtistApi"].get_artist_by_id.return_value = ArtistResource(
+        id=7,
+        foreign_artist_id="artist-id",
+    )
+    lidarr_apis["ArtistLookupApi"].list_artist_lookup.return_value = [
+        ArtistResource(foreign_artist_id="artist-id", folder="Artist (2026)")
+    ]
+
+    assert adapter.get_expected_folder_name(item) == "Artist (2026)"
+    lidarr_apis["ArtistApi"].get_artist_by_id.assert_called_once_with(7)
+
+
+@pytest.mark.parametrize(
+    ("boundary", "api_name", "method_name", "error_context"),
+    [
+        ("list", "ArtistApi", "list_artist", "List Lidarr artists"),
+        ("analysis", "CommandApi", "create_command", "Start Lidarr media analysis"),
+        ("status", "CommandApi", "get_command_by_id", "Read Lidarr command status"),
+        (
+            "preview",
+            "RenameTrackApi",
+            "list_rename",
+            "Preview Lidarr file rename for Artist",
+        ),
+        ("rename", "CommandApi", "create_command", "Start Lidarr file rename"),
+        ("roots", "RootFolderApi", "list_root_folder", "List Lidarr root folders"),
+        ("artist", "ArtistApi", "get_artist_by_id", "Read Lidarr artist Artist"),
+        (
+            "folder",
+            "ArtistLookupApi",
+            "list_artist_lookup",
+            "Resolve Lidarr folder for Artist",
+        ),
+        (
+            "move",
+            "ArtistEditorApi",
+            "put_artist_editor",
+            "Move Lidarr artist folders",
+        ),
+        ("rescan", "CommandApi", "create_command", "Start Lidarr folder rescan"),
+    ],
+)
+def test_translates_api_errors_at_every_boundary(
+    adapter: LidarrAdapter,
+    lidarr_apis: dict[str, MagicMock],
+    boundary: str,
+    api_name: str,
+    method_name: str,
+    error_context: str,
+) -> None:
+    item = MediaItem(1, "Artist", "/music/Artist")
+    file_batch = FileRenameBatch((1,), (10,), "Artist")
+    folder_batch = FolderRenameBatch("/music", (item,))
+    if boundary in {"folder", "rescan"}:
+        adapter._artists[item.id] = ArtistResource(
+            id=item.id,
+            foreign_artist_id="artist-id",
+        )
+    if boundary == "rescan":
+        adapter._expected_folders[item.id] = "Artist"
+    operations = {
+        "list": adapter.list_media_items,
+        "analysis": adapter.start_media_analysis,
+        "status": lambda: adapter.get_command_status(1),
+        "preview": lambda: adapter.get_file_rename_candidate(item),
+        "rename": lambda: adapter.start_file_rename(file_batch),
+        "roots": adapter.list_root_folders,
+        "artist": lambda: adapter.get_expected_folder_name(item),
+        "folder": lambda: adapter.get_expected_folder_name(item),
+        "move": lambda: adapter.move_folder(folder_batch),
+        "rescan": lambda: adapter.start_folder_rescan(folder_batch),
+    }
+    api_error = ApiException(reason="broken")
+    getattr(lidarr_apis[api_name], method_name).side_effect = api_error
+
+    with pytest.raises(ArrOperationError) as error:
+        operations[boundary]()
+
+    assert str(error.value).split(" failed:", maxsplit=1)[0] == error_context
+    assert error.value.__cause__ is api_error
+    assert "broken" in str(error.value)
+
+
+def test_does_not_translate_unexpected_errors(
+    adapter: LidarrAdapter, lidarr_apis: dict[str, MagicMock]
+) -> None:
+    lidarr_apis["ArtistApi"].list_artist.side_effect = RuntimeError("programming error")
+
+    with pytest.raises(RuntimeError, match="programming error"):
+        adapter.list_media_items()
+
+
+@pytest.mark.parametrize(
+    ("operation", "response", "message"),
+    [
+        ("list", ArtistResource(id=1), "Expected a list of artists"),
+        ("analysis", CommandResource(), "^Expected a numeric command ID from Lidarr$"),
+        ("preview", {}, "Expected a list of rename previews"),
+        ("roots", {}, "Expected a list of root folders"),
+        ("lookup", {}, "Expected a list of artist lookup results"),
+    ],
+)
+def test_rejects_malformed_top_level_responses(
+    adapter: LidarrAdapter,
+    lidarr_apis: dict[str, MagicMock],
+    operation: str,
+    response: object,
+    message: str,
+) -> None:
+    item = MediaItem(1, "Artist", "/music/Artist")
+    adapter._artists[item.id] = ArtistResource(
+        id=item.id,
+        foreign_artist_id="artist-id",
+    )
+    operations = {
+        "list": (lidarr_apis["ArtistApi"].list_artist, adapter.list_media_items),
+        "analysis": (
+            lidarr_apis["CommandApi"].create_command,
+            adapter.start_media_analysis,
+        ),
+        "preview": (
+            lidarr_apis["RenameTrackApi"].list_rename,
+            lambda: adapter.get_file_rename_candidate(item),
+        ),
+        "roots": (
+            lidarr_apis["RootFolderApi"].list_root_folder,
+            adapter.list_root_folders,
+        ),
+        "lookup": (
+            lidarr_apis["ArtistLookupApi"].list_artist_lookup,
+            lambda: adapter.get_expected_folder_name(item),
+        ),
+    }
+    api_method, adapter_method = operations[operation]
+    api_method.return_value = response
+
+    with pytest.raises(TypeError, match=message):
+        adapter_method()
+
+
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        ("artist-id", "Expected an artist ID"),
+        ("artist-name", "Expected an artist name"),
+        ("artist-path", "Expected an artist path"),
+        ("track-file", "Expected a track file ID"),
+        ("root-path", "Expected a root-folder path"),
+        ("foreign-id", "Expected a foreign artist ID"),
+        ("lookup-match", "Expected an exact artist lookup result"),
+        ("folder", "Expected an artist folder"),
+    ],
+)
+def test_rejects_missing_required_response_fields(
+    adapter: LidarrAdapter,
+    lidarr_apis: dict[str, MagicMock],
+    operation: str,
+    message: str,
+) -> None:
+    item = MediaItem(1, "Artist", "/music/Artist")
+    artist_api = lidarr_apis["ArtistApi"]
+    rename_api = lidarr_apis["RenameTrackApi"]
+    root_folder_api = lidarr_apis["RootFolderApi"]
+    artist_lookup_api = lidarr_apis["ArtistLookupApi"]
+    if operation == "artist-id":
+        artist_api.list_artist.return_value = [
+            ArtistResource(artist_name="Artist", path="/music/Artist")
+        ]
+        action = adapter.list_media_items
+    elif operation == "artist-name":
+        artist_api.list_artist.return_value = [
+            ArtistResource(id=1, path="/music/Artist")
+        ]
+        action = adapter.list_media_items
+    elif operation == "artist-path":
+        artist_api.list_artist.return_value = [
+            ArtistResource(id=1, artist_name="Artist")
+        ]
+        action = adapter.list_media_items
+    elif operation == "track-file":
+        rename_api.list_rename.return_value = [RenameTrackResource()]
+        action = lambda: adapter.get_file_rename_candidate(item)
+    elif operation == "root-path":
+        root_folder_api.list_root_folder.return_value = [RootFolderResource()]
+        action = adapter.list_root_folders
+    else:
+        foreign_artist_id = None if operation == "foreign-id" else "artist-id"
+        adapter._artists[item.id] = ArtistResource(
+            id=item.id,
+            foreign_artist_id=foreign_artist_id,
+        )
+        if operation == "lookup-match":
+            artist_lookup_api.list_artist_lookup.return_value = []
+        else:
+            artist_lookup_api.list_artist_lookup.return_value = [
+                ArtistResource(foreign_artist_id="artist-id")
+            ]
+        action = lambda: adapter.get_expected_folder_name(item)
+
+    with pytest.raises(TypeError, match=message):
+        action()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -201,7 +201,7 @@ class TestMain:
         assert run_pending.call_count == 2
         assert sleep.call_args_list == [mocker.call(1), mocker.call(1)]
 
-    @pytest.mark.parametrize("service", [ArrService.SONARR, ArrService.RADARR])
+    @pytest.mark.parametrize("service", list(ArrService))
     def test_log_to_file_configures_instance_sink(
         self, config: Config, service: ArrService, mocker: MockerFixture
     ) -> None:
@@ -237,10 +237,14 @@ class TestMain:
 
         self.logging_configurator.configure_instance_file.assert_not_called()
 
-    def test_sonarr_renamarr_scan(self, config, mocker) -> None:
-        config.sonarr[0].renamarr.enabled = True
-        config.sonarr[0].renamarr.analyze_files = True
-        config.sonarr[0].renamarr.rename_folders = True
+    @pytest.mark.parametrize("service", list(ArrService))
+    def test_renamarr_scan(
+        self, config: Config, service: ArrService, mocker: MockerFixture
+    ) -> None:
+        service_config = _service_config(config, service.value)
+        service_config.renamarr.enabled = True
+        service_config.renamarr.analyze_files = True
+        service_config.renamarr.rename_folders = True
         mocker.patch("pyconfigparser.configparser.get_config").return_value = config
         mocker.patch.object(Job, "do")
 
@@ -253,16 +257,16 @@ class TestMain:
         Main().start()
 
         create_arr_adapter.assert_called_once_with(
-            service=ArrService.SONARR,
-            url=config.sonarr[0].url,
-            api_key=config.sonarr[0].api_key,
+            service=service,
+            url=service_config.url,
+            api_key=service_config.api_key,
         )
         renamarr.assert_called_once_with(
-            name=config.sonarr[0].name,
+            name=service_config.name,
             adapter=adapter,
             analyze_files=True,
             rename_folders=True,
-            command_polling=config.sonarr[0].renamarr.command_polling,
+            command_polling=service_config.renamarr.command_polling,
         )
         renamarr.return_value.scan.assert_called_once_with()
         adapter.close.assert_called_once_with()
@@ -325,7 +329,7 @@ class TestMain:
             config=service_config,
         )
 
-    @pytest.mark.parametrize("service", ["sonarr", "radarr"])
+    @pytest.mark.parametrize("service", [service.value for service in ArrService])
     def test_default_renamarr_schedule_runs_immediately_and_hourly(
         self, config: Config, service: str, mocker: MockerFixture
     ) -> None:
@@ -402,6 +406,8 @@ class TestMain:
             (ArrService.SONARR, _service_config(config, "sonarr", 1)),
             (ArrService.RADARR, _service_config(config, "radarr")),
             (ArrService.RADARR, _service_config(config, "radarr", 1)),
+            (ArrService.LIDARR, _service_config(config, "lidarr")),
+            (ArrService.LIDARR, _service_config(config, "lidarr", 1)),
         ]
         for _, instance_config in enabled_instances:
             instance_config.renamarr.enabled = True
@@ -461,7 +467,7 @@ class TestMain:
         assert jobs[0].unit == "minutes"
         self.scheduler_loop.assert_called_once_with()
 
-    @pytest.mark.parametrize("service", ["sonarr", "radarr"])
+    @pytest.mark.parametrize("service", [service.value for service in ArrService])
     def test_deprecated_hourly_job_warns_before_and_after_renamarr_job(
         self, config, service: str, mock_loguru_warning, mocker
     ) -> None:
@@ -606,7 +612,7 @@ class TestMain:
         renamarr.return_value.scan.assert_called_once_with()
         adapter.close.assert_called_once_with()
 
-    @pytest.mark.parametrize("service", ["sonarr", "radarr"])
+    @pytest.mark.parametrize("service", [service.value for service in ArrService])
     def test_disabled_renamarr_schedule_runs_once(
         self, config, service, mocker
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -98,6 +98,18 @@ wheels = [
 ]
 
 [[package]]
+name = "lidarr"
+version = "1.2.1"
+source = { git = "https://github.com/devopsarr/lidarr-py.git?tag=v1.2.1#4f70b4f3302a71a0729e28b4d5cd337947a5ec73" }
+dependencies = [
+    { name = "lazy-imports" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -297,6 +309,7 @@ name = "renamarr"
 version = "1"
 source = { virtual = "." }
 dependencies = [
+    { name = "lidarr" },
     { name = "loguru" },
     { name = "pydantic" },
     { name = "python-config-parser" },
@@ -319,6 +332,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "lidarr", git = "https://github.com/devopsarr/lidarr-py.git?tag=v1.2.1" },
     { name = "loguru", specifier = ">=0.7.3,<0.8" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "python-config-parser", specifier = ">=3.1.3,<4" },


### PR DESCRIPTION
## Summary

- add Lidarr as a third supported Arr service using the pinned `lidarr-py` SDK
- implement artist discovery, media rescans, track rename previews and commands, normalized command polling, SDK error translation, and client cleanup
- resolve expected artist folders through cached Lidarr lookups, move mismatched artist folders by root, and rescan destination folders
- wire Lidarr into the adapter factory, scheduling loop, shared configuration schema, per-service logging, documentation, and example configurations
- refactor the repeated service schema while preserving service-specific validation messages and existing Sonarr/Radarr behavior
- add a mocked Lidarr adapter contract suite plus factory, configuration, scheduling, and logging coverage

## Testing

- `uv run pytest` (398 passed, 100% line and branch coverage)
- `uv run prek --all-files`
